### PR TITLE
Show connection status in the UI

### DIFF
--- a/castable Extension/Handlers/RequestSessionHandler.swift
+++ b/castable Extension/Handlers/RequestSessionHandler.swift
@@ -46,6 +46,7 @@ struct RequestSessionHandler: RequestHandler {
 
         defer {
             // cleanup popover:
+            NSLog("castable: clean up popover")
             AppState.instance.connectingDevice = nil
             SafariExtensionViewController.shared.dismissPopover()
         }

--- a/castable Extension/shared/AppState.swift
+++ b/castable Extension/shared/AppState.swift
@@ -23,6 +23,16 @@ class AppState: ObservableObject {
         self.devices = devices
     }
 
+    func notifyDeviceStop(device: CastDevice) {
+        DispatchQueue.main.startCoroutine {
+            try self.activeApp?.stop().awaitComplete()
+            self.activeApp = nil
+
+            self.activeDevice?.close()
+            self.activeDevice = nil
+        }
+    }
+
     func notifyDeviceSelected(device: CastDevice) {
         for promise in selectionPromises {
             promise.success(device)

--- a/castable Extension/shared/AppState.swift
+++ b/castable Extension/shared/AppState.swift
@@ -19,11 +19,13 @@ class AppState: ObservableObject {
 
     private var selectionPromises: [CoPromise<CastDevice>] = []
 
-    init(withDevices devices: [CastDevice] = []) {
+    init(withDevices devices: [CastDevice] = [], withActive device: CastDevice? = nil) {
         self.devices = devices
+        self.activeDevice = device
     }
 
     func notifyDeviceStop(device: CastDevice) {
+        NSLog("Stopping device")
         DispatchQueue.main.startCoroutine {
             try self.activeApp?.stop().awaitComplete()
             self.activeApp = nil

--- a/castable Extension/shared/AppState.swift
+++ b/castable Extension/shared/AppState.swift
@@ -13,6 +13,7 @@ class AppState: ObservableObject {
     static let instance = AppState()
 
     @Published var devices: [CastDevice]
+    @Published var connectingDevice: CastDevice? = nil
     @Published var activeDevice: CastDevice? = nil
     @Published var activeApp: CastApp? = nil
 

--- a/castable Extension/shared/UI/DeviceRowView.swift
+++ b/castable Extension/shared/UI/DeviceRowView.swift
@@ -26,7 +26,7 @@ struct DeviceRowView: View {
             switch state {
             case .active:
                 Button(action: {
-
+                    AppState.instance.notifyDeviceStop(device: device)
                 }, label: {
                     if #available(OSX 11.0, *) {
                         Image(systemName: "stop.circle")

--- a/castable Extension/shared/UI/DeviceRowView.swift
+++ b/castable Extension/shared/UI/DeviceRowView.swift
@@ -1,0 +1,65 @@
+//
+//  DeviceRowView.swift
+//  castable
+//
+//  Created by Daniel Leong on 12/11/20.
+//
+
+import Foundation
+import SwiftUI
+
+@available(OSX 10.15, *)
+struct DeviceRowView: View {
+    enum State {
+        case none, connecting, active
+    }
+    var device: CastDevice
+    var state: State
+
+    var body: some View {
+        HStack {
+            Button(device.name) {
+               NSLog("castable: select \(device.id)")
+                AppState.instance.notifyDeviceSelected(device: device)
+            }.padding(4)
+
+            switch state {
+            case .active:
+                Button(action: {
+
+                }, label: {
+                    if #available(OSX 11.0, *) {
+                        Image(systemName: "stop.circle")
+                    } else {
+                        // TODO ?
+                    }
+                })
+
+            case .connecting:
+                if #available(OSX 11.0, *) {
+                    ProgressView()
+                        .progressViewStyle(CircularProgressViewStyle())
+                        .scaleEffect(0.5, anchor: .center)
+
+                } else {
+                    // Fallback on earlier versions
+                }
+
+            case .none:
+                Text(verbatim: "") // cannot have "break" so...
+            }
+        }
+    }
+    
+}
+
+@available(OSX 10.15, *)
+struct DeviceRowView_Previews: PreviewProvider {
+    static var previews: some View {
+        VStack(alignment: .leading) {
+            DeviceRowView(device: CastDevice(withName: "Captain's TV"), state: .none)
+            DeviceRowView(device: CastDevice(withName: "Jayne's Brain"), state: .connecting)
+            DeviceRowView(device: CastDevice(withName: "Mess Hall TV"), state: .active)
+        }
+    }
+}

--- a/castable Extension/shared/UI/PopoverView.swift
+++ b/castable Extension/shared/UI/PopoverView.swift
@@ -22,9 +22,10 @@ struct PopoverView: View {
 
     private func computeState(of device: CastDevice) -> DeviceRowView.State {
         // ought to be a cleaner way...
-        if appState.connectingDevice === device {
+
+        if appState.connectingDevice?.id == device.id {
             return .connecting
-        } else if appState.activeDevice === device {
+        } else if appState.activeDevice?.id == device.id {
             return .active
         } else {
             return .none
@@ -39,6 +40,6 @@ struct PopoverView_Previews: PreviewProvider {
             AppState(withDevices: [
                 CastDevice(withName: "Captain's TV"),
                 CastDevice(withName: "Mess Hall TV"),
-            ]))
+            ], withActive: CastDevice(withName: "Mess Hall TV")))
     }
 }

--- a/castable Extension/shared/UI/PopoverView.swift
+++ b/castable Extension/shared/UI/PopoverView.swift
@@ -15,13 +15,20 @@ struct PopoverView: View {
     var body: some View {
         VStack(alignment: .leading) {
             List(appState.devices) { device in
-                Button(device.name) {
-                   NSLog("castable: select \(device.id)")
-                   appState.notifyDeviceSelected(device: device)
-                }
+                DeviceRowView(device: device, state: computeState(of: device))
             }
         }
-        .padding()
+    }
+
+    private func computeState(of device: CastDevice) -> DeviceRowView.State {
+        // ought to be a cleaner way...
+        if appState.connectingDevice === device {
+            return .connecting
+        } else if appState.activeDevice === device {
+            return .active
+        } else {
+            return .none
+        }
     }
 }
 
@@ -30,7 +37,8 @@ struct PopoverView_Previews: PreviewProvider {
     static var previews: some View {
         PopoverView().environmentObject(
             AppState(withDevices: [
-                CastDevice(withName: "Family Room TV")
+                CastDevice(withName: "Captain's TV"),
+                CastDevice(withName: "Mess Hall TV"),
             ]))
     }
 }

--- a/castable.xcodeproj/project.pbxproj
+++ b/castable.xcodeproj/project.pbxproj
@@ -22,6 +22,8 @@
 		B65D89F525818C3800C2C645 /* EventSubscriber.swift in Sources */ = {isa = PBXBuildFile; fileRef = B65D89F425818C3800C2C645 /* EventSubscriber.swift */; };
 		B65D89FB25818D4900C2C645 /* SessionMessageSubscriber.swift in Sources */ = {isa = PBXBuildFile; fileRef = B65D89FA25818D4900C2C645 /* SessionMessageSubscriber.swift */; };
 		B65D8A0325818F9700C2C645 /* EventSubscriptionRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = B65D8A0225818F9700C2C645 /* EventSubscriptionRegistry.swift */; };
+		B691FF162583B23400FF89CA /* DeviceRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B691FF152583B23400FF89CA /* DeviceRowView.swift */; };
+		B691FF172583B23400FF89CA /* DeviceRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B691FF152583B23400FF89CA /* DeviceRowView.swift */; };
 		B6CAACDA2577F2680019B1CC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6CAACD92577F2680019B1CC /* AppDelegate.swift */; };
 		B6CAACDD2577F2680019B1CC /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B6CAACDB2577F2680019B1CC /* Main.storyboard */; };
 		B6CAACDF2577F2680019B1CC /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6CAACDE2577F2680019B1CC /* ViewController.swift */; };
@@ -133,6 +135,7 @@
 		B65D89F425818C3800C2C645 /* EventSubscriber.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventSubscriber.swift; sourceTree = "<group>"; };
 		B65D89FA25818D4900C2C645 /* SessionMessageSubscriber.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionMessageSubscriber.swift; sourceTree = "<group>"; };
 		B65D8A0225818F9700C2C645 /* EventSubscriptionRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventSubscriptionRegistry.swift; sourceTree = "<group>"; };
+		B691FF152583B23400FF89CA /* DeviceRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceRowView.swift; sourceTree = "<group>"; };
 		B6CAACD52577F2680019B1CC /* castable.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = castable.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B6CAACD82577F2680019B1CC /* castable.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = castable.entitlements; sourceTree = "<group>"; };
 		B6CAACD92577F2680019B1CC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -267,6 +270,7 @@
 			isa = PBXGroup;
 			children = (
 				B6EEE5CF257BC6990051E721 /* PopoverView.swift */,
+				B691FF152583B23400FF89CA /* DeviceRowView.swift */,
 			);
 			path = UI;
 			sourceTree = "<group>";
@@ -569,6 +573,7 @@
 				B6CAACDA2577F2680019B1CC /* AppDelegate.swift in Sources */,
 				B6D9D0DD257C4C9000FBC92E /* CastChannel.swift in Sources */,
 				B6EEE638257C28680051E721 /* cast_channel.pb.swift in Sources */,
+				B691FF162583B23400FF89CA /* DeviceRowView.swift in Sources */,
 				B6D9D0EF257C740700FBC92E /* protocol.swift in Sources */,
 				B6D3F1E6257FC3710041854E /* Coroutine+Extensions.swift in Sources */,
 				B6EEE5DC257BCD7C0051E721 /* AppState.swift in Sources */,
@@ -613,6 +618,7 @@
 				B6D9D0F0257C740700FBC92E /* protocol.swift in Sources */,
 				B6459221257A9DA00034F034 /* CastServiceDescriptor.swift in Sources */,
 				B6EEE60C257BEBE90051E721 /* CastSocket.swift in Sources */,
+				B691FF172583B23400FF89CA /* DeviceRowView.swift in Sources */,
 				B6EEE5DD257BCD7C0051E721 /* AppState.swift in Sources */,
 				B645922C257AF5070034F034 /* Message.swift in Sources */,
 				B6D9D0FF257D121200FBC92E /* errors.swift in Sources */,


### PR DESCRIPTION
This does not detect running apps launched elsewhere, yet, but is convenient for stopping playback now that we can launch playback on some apps

- Add initial UI for indicating device connection status
- Add initial stop button binding
- Improve UI checks for device state
