### PR TITLE
Make sockets more robust

### DIFF
--- a/castable Extension/Handlers/SessionSendHandler.swift
+++ b/castable Extension/Handlers/SessionSendHandler.swift
@@ -24,9 +24,9 @@ struct SessionSendHandler: RequestHandler {
 
         let ch = try app.channel(withNamespace: req.namespace).await()
         if let message = req.stringMessage {
-            ch.write(payload: .string(value: message))
+            try ch.write(payload: .string(value: message))
         } else if let dictMessage = request?["dictMessage"] as? [String : Any] {
-            ch.write(payload: .json(value: dictMessage))
+            try ch.write(payload: .json(value: dictMessage))
         }
 
         return [:]

--- a/castable Extension/shared/Cast/CastChannel.swift
+++ b/castable Extension/shared/Cast/CastChannel.swift
@@ -46,6 +46,10 @@ class CastChannel {
 
         DispatchQueue.main.startCoroutine(in: myScope) {
             let incoming = self.socket.receive(in: myScope)
+            incoming.whenCanceled {
+                ch.cancel()
+            }
+
             do {
                 for message in incoming.makeIterator() {
                     if message.ns != self.namespace {

--- a/castable Extension/shared/Cast/CastDevice.swift
+++ b/castable Extension/shared/Cast/CastDevice.swift
@@ -68,7 +68,7 @@ class CastDevice: CustomStringConvertible, Identifiable {
 
     func channel(withNamespace namespace: String, withOptions opts: CastChannel.Options = CastChannel.Options()) -> CoFuture<CastChannel> {
         return DispatchQueue.main.coroutineFuture {
-            let socket = self.ensureConnected()
+            let socket = try self.ensureConnected()
             return CastChannel(on: socket, withNamespace: namespace, withOptions: opts)
         }
     }
@@ -86,7 +86,7 @@ class CastDevice: CustomStringConvertible, Identifiable {
         socket = nil
     }
 
-    private func ensureConnected() -> CastSocket {
+    private func ensureConnected() throws -> CastSocket {
         if let socket = socket, socket.isConnected {
             return socket
         }
@@ -104,15 +104,15 @@ class CastDevice: CustomStringConvertible, Identifiable {
         newSocket.open()
         self.socket = newSocket
 
-        prepare(connection: newSocket)
+        try prepare(connection: newSocket)
 
         return newSocket
     }
 
-    private func prepare(connection: CastSocket) {
+    private func prepare(connection: CastSocket) throws {
         // CONNECT to the device
         let receiver = CastChannel(on: connection, withNamespace: Namespaces.connection);
-        receiver.write(payload: .json(value: ["type": "CONNECT"]))
+        try receiver.write(payload: .json(value: ["type": "CONNECT"]))
 
         // handle heartbeat
         heartbeat?.close()

--- a/castable Extension/shared/Cast/CastError.swift
+++ b/castable Extension/shared/Cast/CastError.swift
@@ -13,6 +13,7 @@ enum CastError: Error {
     case notAvailable
     case notConnected
     case timeout
+    case unableToEncode(message: [String : Any], cause: Error)
     case unableToParse(bytesCount: Int, hex: String)
     case unexpectedResponse(response: Any?)
 }

--- a/castable Extension/shared/Cast/CastError.swift
+++ b/castable Extension/shared/Cast/CastError.swift
@@ -8,8 +8,11 @@
 import Foundation
 
 enum CastError: Error {
+    case eof
     case noResponse
     case notAvailable
+    case notConnected
     case timeout
+    case unableToParse(bytesCount: Int, hex: String)
     case unexpectedResponse(response: Any?)
 }

--- a/castable Extension/shared/Cast/CastSocket.swift
+++ b/castable Extension/shared/Cast/CastSocket.swift
@@ -58,11 +58,6 @@ class CastSocket {
                 NSLog("castable: connection(\(address)) READY")
                 self.startReading(from: conn)
 
-                // TODO this probably belongs elsewhere...
-                try? self.write(message: CastMessage(
-                    ns: "urn:x-cast:com.google.cast.tp.heartbeat",
-                    data: .json(value: [ "type": "PING" ])))
-
             case .failed(let error):
                 NSLog("castable: connection(\(address)) FAILED: \(error)")
                 self.close()

--- a/castable Extension/shared/Cast/CastSocket.swift
+++ b/castable Extension/shared/Cast/CastSocket.swift
@@ -19,6 +19,7 @@ class CastSocket {
     private var address: NWEndpoint
     private let senderId: String?
 
+    private var scope = CoScope()
     private var connection: NWConnection? = nil
     private var receivers: [CoChannel<CastMessage>] = []
     private var myNextId = 1
@@ -58,7 +59,7 @@ class CastSocket {
                 self.startReading(from: conn)
 
                 // TODO this probably belongs elsewhere...
-                self.write(message: CastMessage(
+                try? self.write(message: CastMessage(
                     ns: "urn:x-cast:com.google.cast.tp.heartbeat",
                     data: .json(value: [ "type": "PING" ])))
 
@@ -91,10 +92,10 @@ class CastSocket {
         return ch
     }
 
-    func write(message: CastMessage) {
+    func write(message: CastMessage) throws {
         guard let conn = connection else {
-            NSLog("castable: ERROR: not connected")
-            return
+            NSLog("castable: ERROR: attempting to write \(message) when disconnected")
+            throw CastError.notConnected
         }
 
         let message = CastChannel_CastMessage.with {
@@ -145,6 +146,8 @@ class CastSocket {
         connection?.cancel()
         connection = nil
 
+        scope.cancel()
+
         for receiver in receivers {
             receiver.cancel()
         }
@@ -152,35 +155,43 @@ class CastSocket {
     }
 
     private func startReading(from conn: NWConnection) {
-        self.readHeader(from: conn)
-    }
-
-    private func readHeader(from conn: NWConnection) {
-        conn.receiveCompletely(length: 4) { data in
-            let length = UInt32(bigEndian: data.withUnsafeBytes { $0.load(as: UInt32.self) })
-            self.readMessage(from: conn, withLength: Int(length))
+        DispatchQueue.global().startCoroutine(in: scope) {
+            do {
+                try self.readAndDispatchPackets(from: conn)
+            } catch {
+                NSLog("castable: ERROR in socket read loop: \(error) (\(self.receivers.count) receivers)")
+                self.close()
+            }
         }
     }
 
-    private func readMessage(from conn: NWConnection, withLength length: Int) {
-        conn.receiveCompletely(length: length) { data in
-            guard let parsed = try? CastChannel_CastMessage(serializedData: data) else {
-                NSLog("castable: ERROR: failed to parse: \(data.hexEncodedString()) (\(data.count) bytes)")
-                return
-            }
+    private func readAndDispatchPackets(from conn: NWConnection) throws {
+        while conn === self.connection {
+            let packetLength = try self.readHeader(from: conn)
+            let message = try self.readMessage(from: conn, withLength: packetLength)
 
-            let message = CastMessage(from: parsed)
-
-            NSLog("castable: received \(parsed) -> \(message)")
             for receiver in self.receivers {
-                // TODO we should probably send instead of offer
-                receiver.offer(message)
-            }
-
-            if self.connection === conn {
-                self.startReading(from: conn)
+                try receiver.awaitSend(message)
             }
         }
+    }
+
+    private func readHeader(from conn: NWConnection) throws -> Int {
+        let data = try conn.receiveCompletely(length: 4).await()
+        let length = UInt32(bigEndian: data.withUnsafeBytes { $0.load(as: UInt32.self) })
+        return Int(length)
+    }
+
+    private func readMessage(from conn: NWConnection, withLength length: Int) throws -> CastMessage {
+        let data = try conn.receiveCompletely(length: length).await()
+        guard let parsed = try? CastChannel_CastMessage(serializedData: data) else {
+            NSLog("castable: ERROR: failed to parse: \(data.hexEncodedString()) (\(data.count) bytes)")
+            throw CastError.unableToParse(bytesCount: data.count, hex: data.hexEncodedString())
+        }
+
+        let message = CastMessage(from: parsed)
+        NSLog("castable: received \(parsed) -> \(message)")
+        return message
     }
 
     private func insecureTLSParameters() -> NWParameters {
@@ -204,8 +215,25 @@ class CastSocket {
 }
 
 fileprivate extension NWConnection {
-    // TODO coroutine probably?
-    func receiveCompletely(length: Int, completion: @escaping (Data) -> ()) {
+    func receiveCompletely(length: Int) -> CoFuture<Data> {
+        let promise = CoPromise<Data>()
+
+        receiveCompletely(
+            length: length,
+            completion: { data in promise.success(data) },
+            onError: { error in promise.fail(error) }
+        )
+
+        return promise
+    }
+
+    func receiveCompletely(
+        length: Int,
+        completion: @escaping (Data) -> (),
+        onError: @escaping (Error) -> () = { e in
+            NSLog("castable:receiveCompletely ERROR: \(e)")
+        }
+    ) {
         self.receive(
             minimumIncompleteLength: length,
             maximumLength: length
@@ -216,12 +244,12 @@ fileprivate extension NWConnection {
             }
 
             if let error = error {
-                NSLog("castable: ERROR receiving: = \(error)")
+                onError(error)
                 return
             }
 
             if isComplete {
-                NSLog("castable: EOF")
+                onError(CastError.eof)
                 return
             }
 

--- a/castable Extension/shared/Cast/HeartbeatRunner.swift
+++ b/castable Extension/shared/Cast/HeartbeatRunner.swift
@@ -53,6 +53,9 @@ class HeartbeatRunner {
                     .await(timeout: .milliseconds(Int(1000 * self.timeout)))
             } catch (CoFutureError.timeout) {
                 NSLog("castable: WARN: failed to receive heartbeat within deadline")
+            } catch {
+                NSLog("castable: ERROR: performing heartbeat: \(error)")
+                self.close()
             }
         }
     }


### PR DESCRIPTION
The aim of this PR is to improve the robustness of our CastSocket implementation, as well as all the layers built on top of it. Exceptions are propagated better (though we are somewhat limited by CoChannel's inability to propagate any exception except cancellation here), channels are cancelled more consistently, etc. The biggest improvement to stability, however, is probably just from actually responding to PINGs received from the device.

- Try to improve robustness of CastSocket and reading from it
- Track/log heartbeat timeout statistics
- Throw on failure to encode JSON messages instead of silently dropping
- Respond to PINGs correctly; move all heartbeats into Runner
- Cancel the Channel.receive channel when its input Channel cancels
