### PR TITLE
Eagerly manage Device state

### DIFF
--- a/castable Extension/DeviceManager.swift
+++ b/castable Extension/DeviceManager.swift
@@ -1,0 +1,84 @@
+//
+//  DeviceManager.swift
+//  castable Extension
+//
+//  Created by Daniel Leong on 12/16/20.
+//
+
+import Foundation
+import SwiftCoroutine
+
+class DeviceManager {
+    private let discovery: CastDiscovery
+
+    private var managedSet: [String : CastDevice] = [:]
+
+    init(discovery: CastDiscovery, initialDevices: [CastDevice]) {
+        self.discovery = discovery
+
+        for device in initialDevices {
+            managedSet[device.id] = device
+        }
+    }
+
+    func startManaging(in scope: CoScope) {
+        discovery.discover()
+
+        scope.whenComplete {
+            for device in self.managedSet.values {
+                self.stopManaging(device: device)
+            }
+        }
+
+        DispatchQueue.main.startCoroutine(in: scope) {
+            defer {
+                NSLog("castable: end discover handling")
+                self.discovery.stop()
+            }
+
+            let ch = self.discovery.receive()
+            for descriptors in ch.makeIterator() {
+                let anyNew = descriptors.any { self.managedSet[$0.id] == nil }
+                if !anyNew && descriptors.count == self.managedSet.count {
+                    // no change
+                    continue
+                }
+
+                self.onNewDescriptors(descriptors)
+            }
+        }
+    }
+
+    private func onNewDescriptors(_ descriptors: Set<CastServiceDescriptor>) {
+        var newDevicesSet = Set<CastDevice>()
+        for desc in descriptors {
+            if let existing = managedSet[desc.id] {
+                newDevicesSet.insert(existing)
+            } else {
+                let new = CastDevice(withDescriptor: desc)
+                newDevicesSet.insert(new)
+                manage(device: new)
+            }
+        }
+
+        for device in managedSet.values {
+            if !newDevicesSet.contains(device) {
+                stopManaging(device: device)
+            }
+        }
+
+        let newDevices = newDevicesSet.sorted { $0.name < $1.name }
+        AppState.instance.devices = newDevices
+        NSLog("castable: got new devices set: \(newDevices)")
+    }
+
+    private func manage(device: CastDevice) {
+        NSLog("castable: managing new device: \(device)")
+        self.managedSet[device.id] = device
+    }
+
+    private func stopManaging(device: CastDevice) {
+        NSLog("castable: stopManaging old device: \(device)")
+        self.managedSet.removeValue(forKey: device.id)
+    }
+}

--- a/castable Extension/DeviceManager.swift
+++ b/castable Extension/DeviceManager.swift
@@ -12,13 +12,11 @@ class DeviceManager {
     private let discovery: CastDiscovery
 
     private var managedSet: [String : CastDevice] = [:]
+    private var initialDevices: [CastDevice]? = nil
 
     init(discovery: CastDiscovery, initialDevices: [CastDevice]) {
         self.discovery = discovery
-
-        for device in initialDevices {
-            managedSet[device.id] = device
-        }
+        self.initialDevices = initialDevices
     }
 
     func startManaging(in scope: CoScope) {
@@ -27,6 +25,13 @@ class DeviceManager {
         scope.whenComplete {
             for device in self.managedSet.values {
                 self.stopManaging(device: device)
+            }
+        }
+
+        if let initialDevices = self.initialDevices {
+            self.initialDevices = nil
+            for device in initialDevices {
+                self.manage(device: device, in: scope)
             }
         }
 

--- a/castable Extension/shared/Cast/CastDevice.swift
+++ b/castable Extension/shared/Cast/CastDevice.swift
@@ -22,6 +22,8 @@ class CastDevice: CustomStringConvertible, Identifiable {
     }
 
     var id: String {
+        // NOTE: it's vanishingly unlikely that a name will conflict
+        // with an ID, since IDs are UUIDs
         descriptor?.id ?? name
     }
 
@@ -117,5 +119,23 @@ class CastDevice: CustomStringConvertible, Identifiable {
         // handle heartbeat
         heartbeat?.close()
         heartbeat = HeartbeatRunner(on: connection)
+    }
+}
+
+extension CastDevice: Equatable {
+    static func ==(lhs: CastDevice, rhs: CastDevice) -> Bool {
+        // in general all our CastDevices should have descriptors,
+        // but just in case... compare same to same
+        if let left = lhs.descriptor, let right = rhs.descriptor {
+            return left.id == right.id
+        }
+
+        return lhs.name == rhs.name
+    }
+}
+
+extension CastDevice: Hashable {
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
     }
 }

--- a/castable Extension/shared/Cast/CastDevice.swift
+++ b/castable Extension/shared/Cast/CastDevice.swift
@@ -27,6 +27,10 @@ class CastDevice: CustomStringConvertible, Identifiable {
         descriptor?.id ?? name
     }
 
+    var isConnected: Bool {
+        socket?.isConnected == true
+    }
+
     init(withName name: String) {
         self.name = name
     }

--- a/castable Extension/shared/Cast/protocol.swift
+++ b/castable Extension/shared/Cast/protocol.swift
@@ -28,13 +28,15 @@ struct ReceiverApp: Codable {
     let transportId: String
 }
 
+struct ReceiverVolume: Codable {
+    let controlType: String
+    let level: Double
+    let muted: Bool
+    let stepInterval: Double
+}
+
 struct ReceiverStatus: Codable {
     let applications: [ReceiverApp]
     // let userEq: unknown,
-    // volume: {
-    //     controlType: "attenuation",
-    //     level: number,
-    //     muted: boolean,
-    //     stepInterval: number,
-    // }
+    let volume: ReceiverVolume
 }

--- a/castable Extension/shared/UI/PopoverView.swift
+++ b/castable Extension/shared/UI/PopoverView.swift
@@ -23,9 +23,9 @@ struct PopoverView: View {
     private func computeState(of device: CastDevice) -> DeviceRowView.State {
         // ought to be a cleaner way...
 
-        if appState.connectingDevice?.id == device.id {
+        if appState.connectingDevice == device {
             return .connecting
-        } else if appState.activeDevice?.id == device.id {
+        } else if appState.activeDevice == device {
             return .active
         } else {
             return .none

--- a/castable.xcodeproj/project.pbxproj
+++ b/castable.xcodeproj/project.pbxproj
@@ -8,9 +8,10 @@
 
 /* Begin PBXBuildFile section */
 		19A4343B31E9F0397677F1F5 /* SendMediaCommandHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B64BB6A38F5CC1718313C40 /* SendMediaCommandHandler.swift */; };
+		28BA4837BF4E963C8AC2FCB1 /* DeviceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C846431555C1C5F8BEB5316A /* DeviceManager.swift */; };
 		66566EC6E9A032C371BDE9F5 /* Collection+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C717307ED3C6C991DC786C83 /* Collection+Extensions.swift */; };
 		6ED0F2182F18042A0314AF59 /* HeartbeatRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 674B1BA3FA8209C6D149F89D /* HeartbeatRunner.swift */; };
-		B63889E2257B3F0C00687FBE /* SwiftCoroutine in Frameworks */ = {isa = PBXBuildFile; productRef = B63889E1257B3F0C00687FBE /* SwiftCoroutine */; };
+		B63889E2257B3F0C00687FBE /* BuildFile in Frameworks */ = {isa = PBXBuildFile; productRef = B63889E1257B3F0C00687FBE /* SwiftPackageProductDependency */; };
 		B645920A257A8BEA0034F034 /* CastDiscovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F9DECE25797DB900DC86A9 /* CastDiscovery.swift */; };
 		B645921C257A9D5F0034F034 /* CastDevice.swift in Sources */ = {isa = PBXBuildFile; fileRef = B645921B257A9D5F0034F034 /* CastDevice.swift */; };
 		B6459221257A9DA00034F034 /* CastServiceDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6459220257A9DA00034F034 /* CastServiceDescriptor.swift */; };
@@ -42,7 +43,7 @@
 		B6CAAD102577F2690019B1CC /* SafariExtensionViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = B6CAAD0E2577F2690019B1CC /* SafariExtensionViewController.xib */; };
 		B6D3F1E6257FC3710041854E /* Coroutine+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6D3F1E5257FC3710041854E /* Coroutine+Extensions.swift */; };
 		B6D3F1E7257FC3710041854E /* Coroutine+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6D3F1E5257FC3710041854E /* Coroutine+Extensions.swift */; };
-		B6D9D0D8257C2CB900FBC92E /* SwiftProtobuf in Frameworks */ = {isa = PBXBuildFile; productRef = B6D9D0D7257C2CB900FBC92E /* SwiftProtobuf */; };
+		B6D9D0D8257C2CB900FBC92E /* BuildFile in Frameworks */ = {isa = PBXBuildFile; productRef = B6D9D0D7257C2CB900FBC92E /* SwiftPackageProductDependency */; };
 		B6D9D0DD257C4C9000FBC92E /* CastChannel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6D9D0DC257C4C9000FBC92E /* CastChannel.swift */; };
 		B6D9D0DE257C4C9000FBC92E /* CastChannel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6D9D0DC257C4C9000FBC92E /* CastChannel.swift */; };
 		B6D9D0E3257C5B1400FBC92E /* CastError.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6D9D0E2257C5B1400FBC92E /* CastError.swift */; };
@@ -64,10 +65,10 @@
 		B6EEE5E1257BCE1B0051E721 /* CastDiscovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F9DECE25797DB900DC86A9 /* CastDiscovery.swift */; };
 		B6EEE5E2257BCE1B0051E721 /* CastDevice.swift in Sources */ = {isa = PBXBuildFile; fileRef = B645921B257A9D5F0034F034 /* CastDevice.swift */; };
 		B6EEE5E3257BCE1B0051E721 /* CastServiceDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6459220257A9DA00034F034 /* CastServiceDescriptor.swift */; };
-		B6EEE5EC257BD7220051E721 /* SwiftCoroutine in Frameworks */ = {isa = PBXBuildFile; productRef = B6EEE5EB257BD7220051E721 /* SwiftCoroutine */; };
+		B6EEE5EC257BD7220051E721 /* BuildFile in Frameworks */ = {isa = PBXBuildFile; productRef = B6EEE5EB257BD7220051E721 /* SwiftPackageProductDependency */; };
 		B6EEE5F2257BD7C10051E721 /* SafariExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6EEE5F0257BD7C10051E721 /* SafariExtensions.swift */; };
-		B6EEE5FE257BEA5C0051E721 /* SwiftProtobuf in Frameworks */ = {isa = PBXBuildFile; productRef = B6EEE5FD257BEA5C0051E721 /* SwiftProtobuf */; };
-		B6EEE600257BEA5C0051E721 /* SwiftProtobufPluginLibrary in Frameworks */ = {isa = PBXBuildFile; productRef = B6EEE5FF257BEA5C0051E721 /* SwiftProtobufPluginLibrary */; };
+		B6EEE5FE257BEA5C0051E721 /* BuildFile in Frameworks */ = {isa = PBXBuildFile; productRef = B6EEE5FD257BEA5C0051E721 /* SwiftPackageProductDependency */; };
+		B6EEE600257BEA5C0051E721 /* BuildFile in Frameworks */ = {isa = PBXBuildFile; productRef = B6EEE5FF257BEA5C0051E721 /* SwiftPackageProductDependency */; };
 		B6EEE60B257BEBE90051E721 /* CastSocket.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6EEE60A257BEBE90051E721 /* CastSocket.swift */; };
 		B6EEE60C257BEBE90051E721 /* CastSocket.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6EEE60A257BEBE90051E721 /* CastSocket.swift */; };
 		B6EEE611257C21FC0051E721 /* CastMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6EEE610257C21FC0051E721 /* CastMessage.swift */; };
@@ -182,6 +183,7 @@
 		B6F9DECE25797DB900DC86A9 /* CastDiscovery.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CastDiscovery.swift; sourceTree = "<group>"; };
 		B6F9DED42579964C00DC86A9 /* castable-script.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = "castable-script.js"; sourceTree = "<group>"; };
 		C717307ED3C6C991DC786C83 /* Collection+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Collection+Extensions.swift"; sourceTree = "<group>"; };
+		C846431555C1C5F8BEB5316A /* DeviceManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DeviceManager.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -189,8 +191,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B6EEE5EC257BD7220051E721 /* SwiftCoroutine in Frameworks */,
-				B6D9D0D8257C2CB900FBC92E /* SwiftProtobuf in Frameworks */,
+				B6EEE5EC257BD7220051E721 /* BuildFile in Frameworks */,
+				B6D9D0D8257C2CB900FBC92E /* BuildFile in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -212,10 +214,10 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B6EEE600257BEA5C0051E721 /* SwiftProtobufPluginLibrary in Frameworks */,
+				B6EEE600257BEA5C0051E721 /* BuildFile in Frameworks */,
 				B6CAAD032577F2690019B1CC /* Cocoa.framework in Frameworks */,
-				B63889E2257B3F0C00687FBE /* SwiftCoroutine in Frameworks */,
-				B6EEE5FE257BEA5C0051E721 /* SwiftProtobuf in Frameworks */,
+				B63889E2257B3F0C00687FBE /* BuildFile in Frameworks */,
+				B6EEE5FE257BEA5C0051E721 /* BuildFile in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -360,6 +362,7 @@
 				B6CAAD112577F2690019B1CC /* Info.plist */,
 				B6CAAD122577F2690019B1CC /* castable_Extension.entitlements */,
 				B6CAAD092577F2690019B1CC /* Resources */,
+				C846431555C1C5F8BEB5316A /* DeviceManager.swift */,
 			);
 			path = "castable Extension";
 			sourceTree = "<group>";
@@ -415,8 +418,8 @@
 			);
 			name = castable;
 			packageProductDependencies = (
-				B6EEE5EB257BD7220051E721 /* SwiftCoroutine */,
-				B6D9D0D7257C2CB900FBC92E /* SwiftProtobuf */,
+				B6EEE5EB257BD7220051E721 /* SwiftPackageProductDependency */,
+				B6D9D0D7257C2CB900FBC92E /* SwiftPackageProductDependency */,
 			);
 			productName = castable;
 			productReference = B6CAACD52577F2680019B1CC /* castable.app */;
@@ -472,9 +475,9 @@
 			);
 			name = "castable Extension";
 			packageProductDependencies = (
-				B63889E1257B3F0C00687FBE /* SwiftCoroutine */,
-				B6EEE5FD257BEA5C0051E721 /* SwiftProtobuf */,
-				B6EEE5FF257BEA5C0051E721 /* SwiftProtobufPluginLibrary */,
+				B63889E1257B3F0C00687FBE /* SwiftPackageProductDependency */,
+				B6EEE5FD257BEA5C0051E721 /* SwiftPackageProductDependency */,
+				B6EEE5FF257BEA5C0051E721 /* SwiftPackageProductDependency */,
 			);
 			productName = "castable Extension";
 			productReference = B6CAACFD2577F2690019B1CC /* castable Extension.appex */;
@@ -515,8 +518,8 @@
 			);
 			mainGroup = B6CAACCC2577F2680019B1CC;
 			packageReferences = (
-				B63889E0257B3F0C00687FBE /* XCRemoteSwiftPackageReference "SwiftCoroutine" */,
-				B6EEE5FC257BEA5C0051E721 /* XCRemoteSwiftPackageReference "swift-protobuf" */,
+				B63889E0257B3F0C00687FBE /* RemoteSwiftPackageReference */,
+				B6EEE5FC257BEA5C0051E721 /* RemoteSwiftPackageReference */,
 			);
 			productRefGroup = B6CAACD62577F2680019B1CC /* Products */;
 			projectDirPath = "";
@@ -649,6 +652,7 @@
 				B6EEE5F2257BD7C10051E721 /* SafariExtensions.swift in Sources */,
 				F5A0263D5194FEC02F8ED582 /* HeartbeatRunner.swift in Sources */,
 				19A4343B31E9F0397677F1F5 /* SendMediaCommandHandler.swift in Sources */,
+				28BA4837BF4E963C8AC2FCB1 /* DeviceManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1032,7 +1036,7 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		B63889E0257B3F0C00687FBE /* XCRemoteSwiftPackageReference "SwiftCoroutine" */ = {
+		B63889E0257B3F0C00687FBE /* RemoteSwiftPackageReference */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/belozierov/SwiftCoroutine";
 			requirement = {
@@ -1040,7 +1044,7 @@
 				minimumVersion = 2.1.9;
 			};
 		};
-		B6EEE5FC257BEA5C0051E721 /* XCRemoteSwiftPackageReference "swift-protobuf" */ = {
+		B6EEE5FC257BEA5C0051E721 /* RemoteSwiftPackageReference */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/apple/swift-protobuf.git";
 			requirement = {
@@ -1051,29 +1055,29 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		B63889E1257B3F0C00687FBE /* SwiftCoroutine */ = {
+		B63889E1257B3F0C00687FBE /* SwiftPackageProductDependency */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = B63889E0257B3F0C00687FBE /* XCRemoteSwiftPackageReference "SwiftCoroutine" */;
+			package = B63889E0257B3F0C00687FBE /* RemoteSwiftPackageReference */;
 			productName = SwiftCoroutine;
 		};
-		B6D9D0D7257C2CB900FBC92E /* SwiftProtobuf */ = {
+		B6D9D0D7257C2CB900FBC92E /* SwiftPackageProductDependency */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = B6EEE5FC257BEA5C0051E721 /* XCRemoteSwiftPackageReference "swift-protobuf" */;
+			package = B6EEE5FC257BEA5C0051E721 /* RemoteSwiftPackageReference */;
 			productName = SwiftProtobuf;
 		};
-		B6EEE5EB257BD7220051E721 /* SwiftCoroutine */ = {
+		B6EEE5EB257BD7220051E721 /* SwiftPackageProductDependency */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = B63889E0257B3F0C00687FBE /* XCRemoteSwiftPackageReference "SwiftCoroutine" */;
+			package = B63889E0257B3F0C00687FBE /* RemoteSwiftPackageReference */;
 			productName = SwiftCoroutine;
 		};
-		B6EEE5FD257BEA5C0051E721 /* SwiftProtobuf */ = {
+		B6EEE5FD257BEA5C0051E721 /* SwiftPackageProductDependency */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = B6EEE5FC257BEA5C0051E721 /* XCRemoteSwiftPackageReference "swift-protobuf" */;
+			package = B6EEE5FC257BEA5C0051E721 /* RemoteSwiftPackageReference */;
 			productName = SwiftProtobuf;
 		};
-		B6EEE5FF257BEA5C0051E721 /* SwiftProtobufPluginLibrary */ = {
+		B6EEE5FF257BEA5C0051E721 /* SwiftPackageProductDependency */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = B6EEE5FC257BEA5C0051E721 /* XCRemoteSwiftPackageReference "swift-protobuf" */;
+			package = B6EEE5FC257BEA5C0051E721 /* RemoteSwiftPackageReference */;
 			productName = SwiftProtobufPluginLibrary;
 		};
 /* End XCSwiftPackageProductDependency section */


### PR DESCRIPTION
See: https://github.com/dhleong/castable/projects/1#card-51371034

- Move device management to its own class, with device lifecycles
- Elect "active" device based on running applications
- Ensure initial devices get "managed"
- Also inflate state.activeApp if appropriate
