### PR TITLE
Only expose Castable on secure pages, when requested

### DIFF
--- a/castable Extension/ts/chrome.ts
+++ b/castable Extension/ts/chrome.ts
@@ -220,7 +220,7 @@ export class ChromeController {
         this.chrome = new ChromeStub(cast);
     }
 
-    private receivedApiAvailableHandler: GCastApiAvailabilityHandler;
+    public receivedApiAvailableHandler: GCastApiAvailabilityHandler;
 
     public onGCastApiAvailable = (isAvailable: boolean, err: any) => {
         this.debug("received GCast API Availability: ", isAvailable, err);
@@ -229,6 +229,8 @@ export class ChromeController {
     public setGCastApiAvailableHandler(callback: GCastApiAvailabilityHandler) {
         this.debug("requested GCast API Availability: ", callback);
         this.receivedApiAvailableHandler = callback;
+
+        if (callback) callback(true);
     }
 
     public notifyGCastAvailable(isAvailable: boolean) {

--- a/castable Extension/ts/index.ts
+++ b/castable Extension/ts/index.ts
@@ -78,12 +78,18 @@ function initExt() {
     registerCast(registrar);
 }
 
-if (process.env.NODE_ENV !== "production") {
-    _debug.enable("castable:*");
+function init() {
+  if (process.env.NODE_ENV !== "production") {
+      _debug.enable("castable:*");
+  }
+
+  if (window.safari && window.safari.extension) {
+      initExt();
+  } else {
+      initStub();
+  }
 }
 
-if (window.safari && window.safari.extension) {
-    initExt();
-} else {
-    initStub();
+if (window.location.protocol === "https:") {
+    init();
 }

--- a/castable Extension/ts/index.ts
+++ b/castable Extension/ts/index.ts
@@ -79,15 +79,15 @@ function initExt() {
 }
 
 function init() {
-  if (process.env.NODE_ENV !== "production") {
-      _debug.enable("castable:*");
-  }
+    if (process.env.NODE_ENV !== "production") {
+        _debug.enable("castable:*");
+    }
 
-  if (window.safari && window.safari.extension) {
-      initExt();
-  } else {
-      initStub();
-  }
+    if (window.safari && window.safari.extension) {
+        initExt();
+    } else {
+        initStub();
+    }
 }
 
 if (window.location.protocol === "https:") {

--- a/castable Extension/ts/stub.ts
+++ b/castable Extension/ts/stub.ts
@@ -29,13 +29,24 @@ export function init() {
     const cast = new CastStub(new ClientIO(script));
     const controller = new ChromeController(cast);
 
+    const chromeProxy = proxy(controller.chrome, "chrome");
+    const castProxy = proxy(cast, "cast");
+
     Object.defineProperties(window, {
         chrome: {
-            value: proxy(controller.chrome, "chrome"),
+            get() {
+                if (controller.receivedApiAvailableHandler) {
+                    return chromeProxy;
+                }
+            }
         },
 
         cast: {
-            value: proxy(cast, "cast"),
+            get() {
+                if (controller.receivedApiAvailableHandler) {
+                    return castProxy;
+                }
+            },
         },
 
         __onGCastApiAvailable: {

--- a/castable Extension/ts/stub.ts
+++ b/castable Extension/ts/stub.ts
@@ -38,7 +38,7 @@ export function init() {
                 if (controller.receivedApiAvailableHandler) {
                     return chromeProxy;
                 }
-            }
+            },
         },
 
         cast: {


### PR DESCRIPTION
See: https://github.com/dhleong/castable/projects/1#card-51370642

- Don't expose `chrome` or `cast` namespaces unless requested
- Don't even initialize castable on non-https pages
