### PR TITLE
Stop implicitly passing Page to handlers by modifying the request

### DIFF
--- a/castable Extension/Handlers/ListenHandler.swift
+++ b/castable Extension/Handlers/ListenHandler.swift
@@ -17,8 +17,8 @@ struct ListenHandler: RequestHandler {
     let events: RemoteEventEmitter
     let subscriptions: EventSubscriptionRegistry
 
-    func handle(request: [String : Any]?) throws -> [String : Any]? {
-        let (event, handler) = try request.unpackEventHandler()
+    func handle(context: RequestContext, request: [String : Any]?) throws -> [String : Any]? {
+        let (event, handler) = try context.unpackEventHandler(request: request)
 
         events.register(spec: event, handler: handler)
         subscriptions.subscribe(to: event)
@@ -27,12 +27,9 @@ struct ListenHandler: RequestHandler {
     }
 }
 
-extension Optional where Wrapped == Dictionary<String, Any> {
-    func unpackEventHandler() throws -> (EventSpec, EventHandler) {
-        let req: ListenHandler.Request = try self.parseRequest()
-        guard let page = self?[REQUEST_PAGE_KEY] as? SFSafariPage else {
-            throw GenericError.invalidRequest
-        }
+extension RequestContext {
+    func unpackEventHandler(request: [String : Any]?) throws -> (EventSpec, EventHandler) {
+        let req: ListenHandler.Request = try request.parseRequest()
         return (req.event, EventHandler(page: page, listenerId: req.listenerId))
     }
 }

--- a/castable Extension/Handlers/SendMediaCommandHandler.swift
+++ b/castable Extension/Handlers/SendMediaCommandHandler.swift
@@ -20,13 +20,8 @@ struct SendMediaCommandHandler: RequestHandler {
             throw GenericError.invalidRequest
         }
 
-        // this unpacking is a bummer; we should probably bite the bullet
-        // and add a "context" argument (or something) to handle():
-        var toSend = request
-        toSend.removeValue(forKey: REQUEST_PAGE_KEY)
-
         let ch = try app.channel(withNamespace: Namespaces.media).await()
-        try ch.send(data: toSend).awaitComplete()
+        try ch.send(data: request).awaitComplete()
 
         return [:]
     }

--- a/castable Extension/Handlers/UnlistenHandler.swift
+++ b/castable Extension/Handlers/UnlistenHandler.swift
@@ -11,8 +11,8 @@ struct UnlistenHandler: RequestHandler {
     let events: RemoteEventEmitter
     let subscriptions: EventSubscriptionRegistry
 
-    func handle(request: [String : Any]?) throws -> [String : Any]? {
-        let (event, handler) = try request.unpackEventHandler()
+    func handle(context: RequestContext, request: [String : Any]?) throws -> [String : Any]? {
+        let (event, handler) = try context.unpackEventHandler(request: request)
 
         events.unregister(spec: event, handler: handler)
         subscriptions.cancel(spec: event)

--- a/castable Extension/Ipc/RequestHandler.swift
+++ b/castable Extension/Ipc/RequestHandler.swift
@@ -7,11 +7,32 @@
 
 import Foundation
 import SwiftCoroutine
+import SafariServices
+
+struct RequestContext {
+    let page: SFSafariPage
+}
 
 protocol RequestHandler {
     /// Handle the provided request; this will be called in a Coroutine, so
-    /// `await()` etc may be used
+    /// so `await()` etc may be used. By default, simply calls through
+    /// to the overload with a `context`
+    func handle(context: RequestContext, request: [String : Any]?) throws -> [String : Any]?
+
+    /// See the other handle() method; by default this just throws an
+    /// exception; one or the other of these methods MUST be implemented,
+    /// but not both
     func handle(request: [String : Any]?) throws -> [String : Any]?
+}
+
+extension RequestHandler {
+    func handle(context: RequestContext, request: [String : Any]?) throws -> [String : Any]? {
+        return try self.handle(request: request)
+    }
+
+    func handle(request: [String : Any]?) throws -> [String : Any]? {
+        throw GenericError.cancelled
+    }
 }
 
 extension Optional where Wrapped == [String : Any] {

--- a/castable Extension/Ipc/RequestHandlerRegistry.swift
+++ b/castable Extension/Ipc/RequestHandlerRegistry.swift
@@ -21,7 +21,7 @@ class RequestHandlerRegistry {
         handlers[message] = handler
     }
 
-    func dispatch(message: Message, withData data: [String : Any]? = nil) throws -> [String : Any]? {
+    func dispatch(context: RequestContext, message: Message, withData data: [String : Any]? = nil) throws -> [String : Any]? {
         guard let handler = handlers[message] else {
             NSLog("castable: No handler registered for \(message)")
             throw ReqestHandlerError.noRegisteredHandler
@@ -38,6 +38,6 @@ class RequestHandlerRegistry {
         //
         // let decoded = try? decoder.decode(handler.dataType, from: jsonData)
 
-        return try handler.handle(request: data)
+        return try handler.handle(context: context, request: data)
     }
 }

--- a/castable Extension/SafariExtensionHandler.swift
+++ b/castable Extension/SafariExtensionHandler.swift
@@ -8,8 +8,6 @@
 import SafariServices
 import SwiftCoroutine
 
-let REQUEST_PAGE_KEY = ".request.page"
-
 class SafariExtensionHandler: SFSafariExtensionHandler {
     static let cast = CastDiscovery()
 
@@ -105,11 +103,14 @@ class SafariExtensionHandler: SFSafariExtensionHandler {
                 response = nil
             }
 
-            var data = userInfo
-            data?[REQUEST_PAGE_KEY] = page
+            let context = RequestContext(page: page)
 
             do {
-                let fromHandler = try handlers.dispatch(message: message, withData: data)
+                let fromHandler = try handlers.dispatch(
+                    context: context,
+                    message: message,
+                    withData: userInfo
+                )
                 NSLog("castable: responding to sessionRequest: \(userInfo ?? [:])")
 
                 if let fromHandler = fromHandler, response != nil {


### PR DESCRIPTION
We should've done something like this a while ago, but now's as good a
time as any. In particular, this fixes Disney+ support, which we broke
while working on the events framework, since that introduced the
non-serializable value into the request.

Now that we *never* insert non-serializable values into the request
dictionary, and just pass it through as-is, things should be much easier
to reason about.
