### PR TITLE
Implement core cast.framework RemotePlayer functionality

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -14,6 +14,7 @@
     "@typescript-eslint/quotes": ["error", "double"],
     "import/prefer-default-export": 0,
     "arrow-parens": ["error", "as-needed"],
+    "class-methods-use-this": 0,
     "consistent-return": 0,
     "default-case": 0,
     "max-classes-per-file": 0,

--- a/castable Extension/DeviceManager.swift
+++ b/castable Extension/DeviceManager.swift
@@ -95,7 +95,7 @@ class DeviceManager {
             }
 
             let status = try device.status().await()
-            let activeApp = status.applications.first { !$0.isIdleScreen }
+            let activeApp = status.applications?.first { !$0.isIdleScreen }
             if let activeApp = activeApp, state.activeApp == nil {
                 NSLog("castable: \(device) is active: \(status)")
                 state.activeDevice = device

--- a/castable Extension/shared/Cast/CastApp.swift
+++ b/castable Extension/shared/Cast/CastApp.swift
@@ -101,6 +101,10 @@ class CastApp {
 
 fileprivate extension ReceiverStatus {
     func find(app castApp: CastApp) -> ReceiverApp? {
+        guard let applications = self.applications else {
+            return nil
+        }
+
         for app in applications {
             if app.appId == castApp.id {
                 return app

--- a/castable Extension/shared/Cast/protocol.swift
+++ b/castable Extension/shared/Cast/protocol.swift
@@ -36,7 +36,7 @@ struct ReceiverVolume: Codable {
 }
 
 struct ReceiverStatus: Codable {
-    let applications: [ReceiverApp]
+    let applications: [ReceiverApp]?
     // let userEq: unknown,
     let volume: ReceiverVolume
 }

--- a/castable Extension/ts-test/cast.framework/remote-player-events-test.ts
+++ b/castable Extension/ts-test/cast.framework/remote-player-events-test.ts
@@ -1,0 +1,74 @@
+import * as chai from "chai";
+
+import { EventEmitter } from "events";
+import { RemotePlayerEventType } from "../../ts/cast.framework/enums";
+import { RemotePlayer } from "../../ts/cast.framework/remote-player";
+
+import {
+    RemotePlayerChangedEvent,
+    RemotePlayerEventTransformer,
+} from "../../ts/cast.framework/remote-player-events";
+import { Media } from "../../ts/chrome.cast/media/media";
+
+chai.should();
+
+describe("RemotePlayerEventTransformer", () => {
+    let transformer: RemotePlayerEventTransformer;
+    let emitter: EventEmitter;
+    let events: RemotePlayerChangedEvent[];
+    let media: Media;
+    let player: RemotePlayer;
+
+    beforeEach(() => {
+        transformer = new RemotePlayerEventTransformer();
+        emitter = new EventEmitter();
+        events = [];
+
+        media = new Media("", "", null as any);
+        player = new RemotePlayer();
+
+        const appendEvent = (event: RemotePlayerChangedEvent) => {
+            events.push(event);
+        };
+
+        for (const type of Object.values(RemotePlayerEventType)) {
+            emitter.on(type, appendEvent);
+        }
+    });
+
+    it("dispatches appropriate events", () => {
+        media.currentTime = 42;
+
+        transformer.transform(media, player, emitter);
+
+        events.should.deep.contain(
+            new RemotePlayerChangedEvent(
+                RemotePlayerEventType.CURRENT_TIME_CHANGED,
+                "currentTime",
+                42,
+            ),
+        );
+    });
+
+    it("dispatches an 'any' event", () => {
+        media.currentTime = 42;
+
+        transformer.transform(media, player, emitter);
+
+        events.should.deep.contain(
+            new RemotePlayerChangedEvent(
+                RemotePlayerEventType.ANY_CHANGE,
+                "currentTime",
+                42,
+            ),
+        );
+    });
+
+    it("updates the player object", () => {
+        media.currentTime = 42;
+
+        transformer.transform(media, player, emitter);
+
+        player.currentTime.should.equal(42);
+    });
+});

--- a/castable Extension/ts-test/cast.framework/remote-player-events-test.ts
+++ b/castable Extension/ts-test/cast.framework/remote-player-events-test.ts
@@ -71,4 +71,18 @@ describe("RemotePlayerEventTransformer", () => {
 
         player.currentTime.should.equal(42);
     });
+
+    it("does not emit events with null values", () => {
+        media.media = null;
+
+        transformer.transform(media, player, emitter);
+
+        events.should.not.deep.contain(
+            new RemotePlayerChangedEvent(
+                RemotePlayerEventType.MEDIA_INFO_CHANGED,
+                "mediaInfo",
+                null,
+            ),
+        );
+    });
 });

--- a/castable Extension/ts-test/cast.framework/remote-player-test.ts
+++ b/castable Extension/ts-test/cast.framework/remote-player-test.ts
@@ -1,15 +1,39 @@
 import * as chai from "chai";
+import { mock, SinonMock } from "sinon";
+
+import { CastContext } from "../../ts/cast.framework/cast-context";
+import { CastSession } from "../../ts/cast.framework/cast-session";
 import { RemotePlayer, RemotePlayerController } from "../../ts/cast.framework/remote-player";
+import { PlayerState } from "../../ts/chrome.cast/enums";
+import { Media } from "../../ts/chrome.cast/media/media";
+import { IClientIO } from "../../ts/io/model";
+import { stubClientIO } from "../test-util";
 
 chai.should();
 
 describe("RemotePlayerController", () => {
     let controller: RemotePlayerController;
     let player: RemotePlayer;
+    let io: IClientIO;
+    let rpc: SinonMock;
+    let media: Media;
 
     beforeEach(() => {
+        io = stubClientIO();
+        rpc = mock(io.rpc);
+        media = new Media("session", "mediaSession", {} as any);
+
+        const context = new CastContext(io as any);
+        const session = new CastSession(io as any, {}, {} as any, "sessionId");
+        session.getMediaSession = () => media;
+        context.getCurrentSession = () => session;
+
         player = new RemotePlayer();
-        controller = new RemotePlayerController(player);
+        controller = new RemotePlayerController(player, context);
+    });
+
+    afterEach(() => {
+        rpc.verify();
     });
 
     describe("getFormattedTime", () => {
@@ -25,6 +49,34 @@ describe("RemotePlayerController", () => {
 
         it("truncates times > 100", () => {
             controller.getFormattedTime(120 * 3600).should.equal("100:00:00");
+        });
+    });
+
+    describe("media controls", () => {
+        it("delegate to context session", async () => {
+            rpc.expects("sendMediaCommand")
+                .once()
+                .withExactArgs({
+                    type: "PLAY",
+                    mediaSessionId: "mediaSession",
+                })
+                .resolves();
+
+            await controller.playOrPause();
+        });
+
+        it("sends correct PLAY/PAUSE based on media state", async () => {
+            media.playerState = PlayerState.PLAYING;
+
+            rpc.expects("sendMediaCommand")
+                .once()
+                .withExactArgs({
+                    type: "PAUSE",
+                    mediaSessionId: "mediaSession",
+                })
+                .resolves();
+
+            await controller.playOrPause();
         });
     });
 });

--- a/castable Extension/ts-test/cast.framework/remote-player-test.ts
+++ b/castable Extension/ts-test/cast.framework/remote-player-test.ts
@@ -1,0 +1,30 @@
+import * as chai from "chai";
+import { RemotePlayer, RemotePlayerController } from "../../ts/cast.framework/remote-player";
+
+chai.should();
+
+describe("RemotePlayerController", () => {
+    let controller: RemotePlayerController;
+    let player: RemotePlayer;
+
+    beforeEach(() => {
+        player = new RemotePlayer();
+        controller = new RemotePlayerController(player);
+    });
+
+    describe("getFormattedTime", () => {
+        it("Handles very small times", () => {
+            controller.getFormattedTime(42).should.equal("00:00:42");
+        });
+
+        it("Handles full times", () => {
+            const time = 3600 + (42 * 60) + 22;
+            controller.getFormattedTime(time)
+                .should.equal("01:42:22");
+        });
+
+        it("truncates times > 100", () => {
+            controller.getFormattedTime(120 * 3600).should.equal("100:00:00");
+        });
+    });
+});

--- a/castable Extension/ts-test/cast.framework/remote-player-test.ts
+++ b/castable Extension/ts-test/cast.framework/remote-player-test.ts
@@ -3,7 +3,10 @@ import { mock, SinonMock } from "sinon";
 
 import { CastContext } from "../../ts/cast.framework/cast-context";
 import { CastSession } from "../../ts/cast.framework/cast-session";
-import { RemotePlayer, RemotePlayerController } from "../../ts/cast.framework/remote-player";
+import { RemotePlayer } from "../../ts/cast.framework/remote-player";
+import {
+    RemotePlayerController,
+} from "../../ts/cast.framework/remote-player-controller";
 import { PlayerState } from "../../ts/chrome.cast/enums";
 import { Media } from "../../ts/chrome.cast/media/media";
 import { IClientIO } from "../../ts/io/model";

--- a/castable Extension/ts-test/test-util.ts
+++ b/castable Extension/ts-test/test-util.ts
@@ -1,0 +1,27 @@
+import { RpcMessaging } from "../ts/io/messaging";
+import { IClientIO, IRpc } from "../ts/io/model";
+import { Rpc } from "../ts/io/rpc";
+
+export function stubRpc(): IRpc {
+    return new Rpc({
+        createRpc(name: string) {
+            return async () => {
+                throw new Error(`Called un-mocked ${name}`);
+            };
+        },
+    } as unknown as RpcMessaging);
+}
+
+export function stubClientIO(): IClientIO {
+    return {
+        rpc: stubRpc(),
+
+        dispatchMessage() {
+            throw new Error("Not implemented");
+        },
+
+        registerEventListener() {
+            throw new Error("Not implemented");
+        },
+    };
+}

--- a/castable Extension/ts/cast.framework/cast-context.ts
+++ b/castable Extension/ts/cast.framework/cast-context.ts
@@ -115,7 +115,6 @@ export class CastContext {
         }
     }
 
-    // eslint-disable-next-line class-methods-use-this
     public setLaunchCredentialsData(data: any) {
         debug("setLaunchCredentialsData", data);
     }

--- a/castable Extension/ts/cast.framework/cast-session.ts
+++ b/castable Extension/ts/cast.framework/cast-session.ts
@@ -40,6 +40,7 @@ export class CastSession {
 
     private activeInputState = ActiveInputState.ACTIVE_INPUT_STATE_UNKNOWN;
     private sessionState = SessionState.SESSION_STARTED;
+    private mediaSession?: Media;
 
     private onMediaMessage = (_: string, message: string) => {
         const parsed = JSON.parse(message);
@@ -58,6 +59,8 @@ export class CastSession {
                     media: null,
                     currentTime: 0,
                 }, status);
+
+                this.mediaSession = media;
 
                 this.events.emit(SessionEventType.MEDIA_SESSION, {
                     mediaSession: proxy(media, "chrome.cast.media.Media()"),
@@ -165,8 +168,7 @@ export class CastSession {
     // eslint-disable-next-line class-methods-use-this
     public getMediaSession() {
         debug("getMediaSession");
-        // TODO
-        return null;
+        return this.mediaSession;
     }
 
     public getSessionId() {

--- a/castable Extension/ts/cast.framework/cast-session.ts
+++ b/castable Extension/ts/cast.framework/cast-session.ts
@@ -154,7 +154,6 @@ export class CastSession {
         };
     }
 
-    // eslint-disable-next-line class-methods-use-this
     public getApplicationStatus() {
         debug("getApplicationStatus");
         return null; // ?
@@ -165,7 +164,6 @@ export class CastSession {
         return this.device;
     }
 
-    // eslint-disable-next-line class-methods-use-this
     public getMediaSession() {
         debug("getMediaSession");
         return this.mediaSession;
@@ -176,7 +174,6 @@ export class CastSession {
         return this.sessionId;
     }
 
-    // eslint-disable-next-line class-methods-use-this
     public getSessionObj() {
         debug("getSessionObj");
         return {}; // chrome.cast.Session
@@ -187,14 +184,12 @@ export class CastSession {
         return this.sessionState;
     }
 
-    // eslint-disable-next-line class-methods-use-this
     public getVolume() {
         debug("getVolume");
         // TODO
         return 1;
     }
 
-    // eslint-disable-next-line class-methods-use-this
     public isMute() {
         debug("isMute");
         // TODO
@@ -247,13 +242,11 @@ export class CastSession {
         });
     }
 
-    // eslint-disable-next-line class-methods-use-this
     public async setMute(isMute: boolean) {
         debug("setMute", isMute);
         // TODO
     }
 
-    // eslint-disable-next-line class-methods-use-this
     public async setVolume(volume: number) {
         debug("setVolume", volume);
         // TODO

--- a/castable Extension/ts/cast.framework/enums.ts
+++ b/castable Extension/ts/cast.framework/enums.ts
@@ -5,6 +5,38 @@ export enum CastState {
     CONNECTED = "CONNECTED",
 }
 
+export enum RemotePlayerEventType {
+    ANY_CHANGE = "anyChanged",
+    BREAK_CLIP_ID_CHANGED = "breakClipIdChanged",
+    BREAK_ID_CHANGED = "breakIdChanged",
+    CAN_CONTROL_VOLUME_CHANGED = "canControlVolumeChanged",
+    CAN_PAUSE_CHANGED = "canPauseChanged",
+    CAN_SEEK_CHANGED = "canSeekChanged",
+    CURRENT_BREAK_CLIP_NUMBER_CHANGED = "currentBreakClipNumberChanged",
+    CURRENT_BREAK_CLIP_TIME_CHANGED = "currentBreakClipTimeChanged",
+    CURRENT_BREAK_TIME_CHANGED = "currentBreakTimeChanged",
+    CURRENT_TIME_CHANGED = "currentTimeChanged",
+    DISPLAY_NAME_CHANGED = "displayNameChanged",
+    DISPLAY_STATUS_CHANGED = "displayStatusChanged",
+    DURATION_CHANGED = "durationChanged",
+    IMAGE_URL_CHANGED = "imageUrlChanged",
+    IS_CONNECTED_CHANGED = "isConnectedChanged",
+    IS_MEDIA_LOADED_CHANGED = "isMediaLoadedChanged",
+    IS_MUTED_CHANGED = "isMutedChanged",
+    IS_PAUSED_CHANGED = "isPausedChanged",
+    IS_PLAYING_BREAK_CHANGED = "isPlayingBreakChanged",
+    LIVE_SEEKABLE_RANGE_CHANGED = "liveSeekableRangeChanged",
+    MEDIA_INFO_CHANGED = "mediaInfoChanged",
+    NUMBER_BREAK_CLIPS_CHANGED = "numberBreakClipsChanged",
+    PLAYER_STATE_CHANGED = "playerStateChanged",
+    QUEUE_DATA_CHANGED = "queueDataChanged",
+    STATUS_TEXT_CHANGED = "statusTextChanged",
+    TITLE_CHANGED = "titleChanged",
+    VIDEO_INFO_CHANGED = "videoInfoChanged",
+    VOLUME_LEVEL_CHANGED = "volumeLevelChanged",
+    WHEN_SKIPPABLE_CHANGED = "whenSkippableChanged",
+}
+
 export enum SessionEventType {
     APPLICATION_STATUS_CHANGED = "APPLICATION_STATUS_CHANGED",
     APPLICATION_METADATA_CHANGED = "APPLICATION_METADATA_CHANGED",

--- a/castable Extension/ts/cast.framework/remote-player-controller.ts
+++ b/castable Extension/ts/cast.framework/remote-player-controller.ts
@@ -1,0 +1,190 @@
+import _debug from "debug";
+import { EventEmitter } from "events";
+
+import { PlayerState } from "../chrome.cast/enums";
+import { Listener } from "../chrome.cast/generic-types";
+import { Media } from "../chrome.cast/media/media";
+import { IPartialMediaCommand } from "../io/model";
+
+import { CastContext } from "./cast-context";
+import { CastSession, SessionStateEventData } from "./cast-session";
+import { CastContextEventType, RemotePlayerEventType, SessionEventType } from "./enums";
+import { MediaSessionEventData } from "./events";
+import { RemotePlayer } from "./remote-player";
+import { RemotePlayerChangedEvent, RemotePlayerEventTransformer } from "./remote-player-events";
+
+const debug = _debug("castable:cast.framework.RemotePlayerController");
+const MAX_FORMATTABLE_TIME = 100 * 3600; // 100 hours
+
+function findCastableContext() {
+    return (window as any).cast.framework.CastContext.getInstance();
+}
+
+export class RemotePlayerController {
+    private readonly events = new EventEmitter();
+    private readonly transformer = new RemotePlayerEventTransformer();
+
+    private totalListeners = 0;
+
+    constructor(
+        public readonly player: RemotePlayer,
+        private readonly context: CastContext = findCastableContext(),
+    ) {
+        debug("NEW RemotePlayerController with:", player);
+        this.player.controller = this;
+    }
+
+    public addEventListener(
+        type: RemotePlayerEventType,
+        handler: Listener<RemotePlayerChangedEvent>,
+    ) {
+        debug("addEventListener(", type, ")");
+        this.events.on(type, handler);
+
+        const firstListener = !this.totalListeners;
+        ++this.totalListeners;
+
+        if (firstListener) {
+            this.subscribeToEvents();
+        }
+    }
+
+    public getFormattedTime(timeInSec: number) {
+        // NOTE: per docs, intervals > 100 hours get truncated
+        const time = Math.min(MAX_FORMATTABLE_TIME, timeInSec);
+
+        const hours = Math.floor(time / 3600);
+        const minutes = Math.floor((time % 3600) / 60);
+        const seconds = time - (hours * 3600) - (minutes * 60);
+
+        const hoursZero = hours < 10 ? "0" : "";
+        const minutesZero = minutes < 10 ? "0" : "";
+        const secondsZero = seconds < 10 ? "0" : "";
+
+        return `${hoursZero}${hours}:${minutesZero}${minutes}:${secondsZero}${seconds}`;
+    }
+
+    public getSeekPosition(currentTime: number, duration: number) {
+        if (duration <= 0) return 0;
+        return currentTime / duration;
+    }
+
+    public getSeekTime(currentPosition: number, duration: number) {
+        return currentPosition * duration;
+    }
+
+    public readonly muteOrUnmute = this.createMediaCommand(media => ({
+        type: "SET_VOLUME",
+        volume: {
+            muted: media.volume?.muted === false,
+        },
+    }));
+
+    public readonly playOrPause = this.createMediaCommand(media => ({
+        type: media.playerState === PlayerState.PLAYING
+            ? "PAUSE"
+            : "PLAY",
+    }));
+
+    public readonly seek = this.createMediaCommand(() => ({
+        type: "SEEK",
+        currentTime: this.player.currentTime,
+    }));
+
+    public readonly setVolumeLevel = this.createMediaCommand(() => ({
+        type: "SET_VOLUME",
+        volume: {
+            level: this.player.volumeLevel,
+        },
+    }));
+
+    public skipAd = this.createSimpleMediaCommand("SKIP_AD");
+    public stop = this.createSimpleMediaCommand("STOP");
+
+    public removeEventListener(
+        type: RemotePlayerEventType,
+        handler: Listener<RemotePlayerChangedEvent>,
+    ) {
+        this.events.off(type, handler);
+        --this.totalListeners;
+        const isLast = !this.totalListeners;
+
+        if (isLast) {
+            this.unsubscribeFromEvents();
+        }
+    }
+
+    private createSimpleMediaCommand(type: string) {
+        return this.createMediaCommand(() => ({ type }));
+    }
+
+    private createMediaCommand(
+        build: (media: Media) => IPartialMediaCommand,
+    ) {
+        return () => {
+            debug("media command send requested...");
+
+            const session = this.context.getCurrentSession();
+            if (!session) throw new Error("No session");
+
+            const media = session.getMediaSession();
+            if (!media) {
+                debug("NO media session; abandon send request");
+                return;
+            }
+
+            const command = build(media);
+
+            debug("sending media command:", command);
+            return session.io.rpc.sendMediaCommand({
+                ...command,
+                mediaSessionId: media.mediaSessionId,
+            });
+        };
+    }
+
+    private async subscribeToEvents() {
+        debug("subscribe to media events");
+        const session = await this.awaitSession();
+        session.addEventListener(SessionEventType.MEDIA_SESSION, this.onMediaSession);
+    }
+
+    private async unsubscribeFromEvents() {
+        debug("unsubscribe from media events");
+        const session = this.context.getCurrentSession();
+        if (session) {
+            session.removeEventListener(
+                SessionEventType.MEDIA_SESSION,
+                this.onMediaSession,
+            );
+        }
+    }
+
+    private onMediaSession = (session: MediaSessionEventData) => {
+        debug("media=", session.mediaSession);
+
+        this.transformer.transform(
+            session.mediaSession,
+            this.player,
+            this.events,
+        );
+    };
+
+    private async awaitSession() {
+        const { context } = this;
+        const session = context.getCurrentSession();
+        if (session) return session;
+
+        return new Promise<CastSession>(resolve => {
+            function listener(event: SessionStateEventData) {
+                resolve(event.session);
+                context.removeEventListener(
+                    CastContextEventType.SESSION_STATE_CHANGED,
+                    listener,
+                );
+            }
+
+            context.addEventListener(CastContextEventType.SESSION_STATE_CHANGED, listener);
+        });
+    }
+}

--- a/castable Extension/ts/cast.framework/remote-player-events.ts
+++ b/castable Extension/ts/cast.framework/remote-player-events.ts
@@ -29,6 +29,14 @@ function supports(media: Media, mask: number) {
 }
 
 /**
+ * Returns the given value unless it's `null`, in which case
+ * `undefined` is returned instead
+ */
+function ignoreNull<T>(value: T | null | undefined) {
+    return value === null ? undefined : value;
+}
+
+/**
  * A map of RemotePlayer keys to transform functions, which return
  * a new value for that key (or undefined to not change it)
  */
@@ -47,7 +55,7 @@ const transforms: {[key: string]: RemotePlayerTransform} = {
     isMediaLoaded: m => m.media !== undefined,
     isMuted: m => m.volume?.muted,
     isPaused: m => m.playerState === PlayerState.PAUSED,
-    mediaInfo: m => (m.media === null ? undefined : m.media),
+    mediaInfo: m => ignoreNull(m.media),
     playerState: m => m.playerState,
     title: m => m.media?.metadata?.title,
     volumeLevel: m => m.volume?.level,

--- a/castable Extension/ts/cast.framework/remote-player-events.ts
+++ b/castable Extension/ts/cast.framework/remote-player-events.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from "events";
-import { MediaCommand, PlayerState } from "../chrome.cast/enums";
+import { PlayerState } from "../chrome.cast/enums";
 
 import { Media } from "../chrome.cast/media/media";
 import { RemotePlayerEventType } from "./enums";
@@ -17,14 +17,29 @@ interface RemotePlayerTransform {
     (media: Media): any | undefined;
 }
 
+const MEDIA_COMMAND_PAUSE = 0x01;
+const MEDIA_COMMAND_SEEK = 0x02;
+const MEDIA_COMMAND_VOLUME = 0x04;
+
+function supports(media: Media, mask: number) {
+    /* eslint-disable no-bitwise */
+    return ((media.supportedMediaCommands ?? 0) & mask) !== 0;
+}
+
 /**
  * A map of RemotePlayer keys to transform functions, which return
  * a new value for that key (or undefined to not change it)
  */
 const transforms: {[key: string]: RemotePlayerTransform} = {
-    canControlVolume: m => m.supportedMediaCommands?.includes(MediaCommand.STREAM_VOLUME),
-    canPause: m => m.supportedMediaCommands?.includes(MediaCommand.PAUSE),
-    canSeek: m => m.supportedMediaCommands?.includes(MediaCommand.SEEK),
+    // To be restored when supportedMediaCommands has the proper type:
+    // canControlVolume: m => m.supportedMediaCommands?.includes(MediaCommand.STREAM_VOLUME),
+    // canPause: m => m.supportedMediaCommands?.includes(MediaCommand.PAUSE),
+    // canSeek: m => m.supportedMediaCommands?.includes(MediaCommand.SEEK),
+
+    canControlVolume: m => supports(m, MEDIA_COMMAND_VOLUME),
+    canPause: m => supports(m, MEDIA_COMMAND_PAUSE),
+    canSeek: m => supports(m, MEDIA_COMMAND_SEEK),
+
     currentTime: m => m.currentTime,
     duration: m => m.media?.duration,
     isMediaLoaded: m => m.media !== undefined,

--- a/castable Extension/ts/cast.framework/remote-player-events.ts
+++ b/castable Extension/ts/cast.framework/remote-player-events.ts
@@ -1,0 +1,60 @@
+import { EventEmitter } from "events";
+
+import { Media } from "../chrome.cast/media/media";
+import { RemotePlayerEventType } from "./enums";
+import { RemotePlayer } from "./remote-player";
+
+export class RemotePlayerChangedEvent {
+    constructor(
+        public readonly type: RemotePlayerEventType,
+        public readonly field: keyof RemotePlayer,
+        public readonly value: any,
+    ) {}
+}
+
+interface RemotePlayerTransform {
+    (media: Media): any | undefined;
+}
+
+const transforms: {[key: string]: RemotePlayerTransform} = {
+    currentTime: m => m.currentTime,
+    title: m => m.media?.metadata?.title,
+};
+
+export class RemotePlayerEventTransformer {
+    private static keyToChangedEvent = Object.keys(RemotePlayerEventType)
+        .reduce((m, key) => {
+            const value = (RemotePlayerEventType as any)[key];
+            // eslint-disable-next-line no-param-reassign
+            m[value.replace(/Changed/, "")] = value;
+            return m;
+        }, {} as {[key: string]: RemotePlayerEventType});
+
+    public transform(
+        media: Media,
+        player: RemotePlayer,
+        events: EventEmitter,
+    ) {
+        /* eslint-disable no-param-reassign */
+        const keys = Object.keys(transforms) as (keyof RemotePlayer)[];
+
+        for (const key of keys) {
+            const transform = transforms[key];
+            const value = transform(media);
+            if (value === undefined) continue;
+
+            (player as any)[key] = value;
+            const type = RemotePlayerEventTransformer.keyToChangedEvent[key];
+
+            events.emit(type, new RemotePlayerChangedEvent(type, key, value));
+            events.emit(
+                RemotePlayerEventType.ANY_CHANGE,
+                new RemotePlayerChangedEvent(
+                    RemotePlayerEventType.ANY_CHANGE,
+                    key,
+                    value,
+                ),
+            );
+        }
+    }
+}

--- a/castable Extension/ts/cast.framework/remote-player-events.ts
+++ b/castable Extension/ts/cast.framework/remote-player-events.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from "events";
+import { MediaCommand, PlayerState } from "../chrome.cast/enums";
 
 import { Media } from "../chrome.cast/media/media";
 import { RemotePlayerEventType } from "./enums";
@@ -16,9 +17,23 @@ interface RemotePlayerTransform {
     (media: Media): any | undefined;
 }
 
+/**
+ * A map of RemotePlayer keys to transform functions, which return
+ * a new value for that key (or undefined to not change it)
+ */
 const transforms: {[key: string]: RemotePlayerTransform} = {
+    canControlVolume: m => m.supportedMediaCommands?.includes(MediaCommand.STREAM_VOLUME),
+    canPause: m => m.supportedMediaCommands?.includes(MediaCommand.PAUSE),
+    canSeek: m => m.supportedMediaCommands?.includes(MediaCommand.SEEK),
     currentTime: m => m.currentTime,
+    duration: m => m.media?.duration,
+    isMediaLoaded: m => m.media !== undefined,
+    isMuted: m => m.volume?.muted,
+    isPaused: m => m.playerState === PlayerState.PAUSED,
+    mediaInfo: m => m.media,
+    playerState: m => m.playerState,
     title: m => m.media?.metadata?.title,
+    volumeLevel: m => m.volume?.level,
 };
 
 export class RemotePlayerEventTransformer {

--- a/castable Extension/ts/cast.framework/remote-player-events.ts
+++ b/castable Extension/ts/cast.framework/remote-player-events.ts
@@ -1,7 +1,9 @@
+import _debug from "debug";
 import { EventEmitter } from "events";
-import { PlayerState } from "../chrome.cast/enums";
 
+import { PlayerState } from "../chrome.cast/enums";
 import { Media } from "../chrome.cast/media/media";
+
 import { RemotePlayerEventType } from "./enums";
 import { RemotePlayer } from "./remote-player";
 
@@ -51,6 +53,8 @@ const transforms: {[key: string]: RemotePlayerTransform} = {
     volumeLevel: m => m.volume?.level,
 };
 
+const debug = _debug("castable:cast.framework.RemotePlayerEventTransformer");
+
 export class RemotePlayerEventTransformer {
     private static keyToChangedEvent = Object.keys(RemotePlayerEventType)
         .reduce((m, key) => {
@@ -73,8 +77,12 @@ export class RemotePlayerEventTransformer {
             const value = transform(media);
             if (value === undefined) continue;
 
+            const oldValue = player[key];
+            if (oldValue === value) continue;
+
             (player as any)[key] = value;
             const type = RemotePlayerEventTransformer.keyToChangedEvent[key];
+            debug(media.sessionId, ".", key, "CHANGED:", type, oldValue, value);
 
             events.emit(type, new RemotePlayerChangedEvent(type, key, value));
             events.emit(

--- a/castable Extension/ts/cast.framework/remote-player.ts
+++ b/castable Extension/ts/cast.framework/remote-player.ts
@@ -1,9 +1,97 @@
+import _debug from "debug";
+import { EventEmitter } from "events";
+
+import { Listener } from "../chrome.cast/generic-types";
+import { RemotePlayerEventType } from "./enums";
+
 export class RemotePlayer {
-    // TODO
+    public controller: RemotePlayerController | undefined;
+
+    public currentTime = 0;
+    public volumeLevel = 1;
 }
 
+export class RemotePlayerChangedEvent {
+    constructor(
+        public readonly type: RemotePlayerEventType,
+        public readonly field: string,
+        public readonly value: any,
+    ) {}
+}
+
+const debug = _debug("castable:cast.framework.RemotePlayerController");
+const MAX_FORMATTABLE_TIME = 100 * 3600; // 100 hours
+
 export class RemotePlayerController {
+    private readonly events = new EventEmitter();
+
     constructor(
         public readonly player: RemotePlayer,
-    ) {}
+    ) {
+        debug("NEW RemotePlayerController with:", player);
+        this.player.controller = this;
+    }
+
+    public addEventListener(
+        type: RemotePlayerEventType,
+        handler: Listener<RemotePlayerChangedEvent>,
+    ) {
+        debug("TODO addEventListener(", type, ")");
+        this.events.on(type, handler);
+    }
+
+    public getFormattedTime(timeInSec: number) {
+        // NOTE: per docs, intervals > 100 hours get truncated
+        const time = Math.min(MAX_FORMATTABLE_TIME, timeInSec);
+
+        const hours = Math.floor(time / 3600);
+        const minutes = Math.floor((time % 3600) / 60);
+        const seconds = time - (hours * 3600) - (minutes * 60);
+
+        const hoursZero = hours < 10 ? "0" : "";
+        const minutesZero = minutes < 10 ? "0" : "";
+        const secondsZero = seconds < 10 ? "0" : "";
+
+        return `${hoursZero}${hours}:${minutesZero}${minutes}:${secondsZero}${seconds}`;
+    }
+
+    public getSeekPosition(currentTime: number, duration: number) {
+        if (duration <= 0) return 0;
+        return currentTime / duration;
+    }
+
+    public getSeekTime(currentPosition: number, duration: number) {
+        return currentPosition * duration;
+    }
+
+    public async muteOrUnmute() {
+        debug("TODO: muteOrUnmute");
+    }
+
+    public async playOrPause() {
+        debug("TODO: playOrPause");
+    }
+
+    public async seek() {
+        debug("TODO: seek to:", this.player.currentTime);
+    }
+
+    public async setVolumeLevel() {
+        debug("TODO: set volume to:", this.player.volumeLevel);
+    }
+
+    public async skipAd() {
+        debug("TODO: skip ad");
+    }
+
+    public async stop() {
+        debug("TODO: stop");
+    }
+
+    public removeEventListener(
+        type: RemotePlayerEventType,
+        handler: Listener<RemotePlayerChangedEvent>,
+    ) {
+        this.events.off(type, handler);
+    }
 }

--- a/castable Extension/ts/cast.framework/remote-player.ts
+++ b/castable Extension/ts/cast.framework/remote-player.ts
@@ -1,196 +1,38 @@
-import _debug from "debug";
-import { EventEmitter } from "events";
-
 import { PlayerState } from "../chrome.cast/enums";
-import { Listener } from "../chrome.cast/generic-types";
-import { Media } from "../chrome.cast/media/media";
-import { IPartialMediaCommand } from "../io/model";
-
-import { CastContext } from "./cast-context";
-import { CastSession, SessionStateEventData } from "./cast-session";
-import { CastContextEventType, RemotePlayerEventType, SessionEventType } from "./enums";
-import { MediaSessionEventData } from "./events";
+import { MediaInfo } from "../chrome.cast/media/media";
 
 export class RemotePlayer {
-    public controller: RemotePlayerController | undefined;
+    // NOTE: can only be RemotePlayerController, but we're using
+    // unknown here to avoid a circular dependency
+    public controller: any | undefined;
 
+    public breakClipId?: string;
+    public breakId?: string;
+    public canControlVolume = true;
+    public canPause = true;
+    public canSeek = true;
+    public currentBreakClipNumber?: number;
+    public currentBreakClipTime?: number;
+    public currentBreakTime?: number;
     public currentTime = 0;
+    public displayName = "";
+    public displayStatus = "";
+    public duration = 0;
+    public imageUrl?: string;
+    public isConnected = true;
+    public isMediaLoaded = false;
+    public isMuted = false;
+    public isPaused = false;
+    public isPlayingBreak = false;
+    public liveSeekableRange = undefined; // TODO
+    public mediaInfo?: MediaInfo;
+    public numberBreakClips = 0;
+    public playerState?: PlayerState;
+    public queueData = undefined; // TODO
+    public savedPlayerState = undefined; // TODO
+    public statusText = "";
+    public title?: string;
+    public videoInfo = undefined; // TODO
     public volumeLevel = 1;
-}
-
-export class RemotePlayerChangedEvent {
-    constructor(
-        public readonly type: RemotePlayerEventType,
-        public readonly field: string,
-        public readonly value: any,
-    ) {}
-}
-
-const debug = _debug("castable:cast.framework.RemotePlayerController");
-const MAX_FORMATTABLE_TIME = 100 * 3600; // 100 hours
-
-function findCastableContext() {
-    return (window as any).cast.framework.CastContext.getInstance();
-}
-
-export class RemotePlayerController {
-    private readonly events = new EventEmitter();
-    private totalListeners = 0;
-
-    constructor(
-        public readonly player: RemotePlayer,
-        private readonly context: CastContext = findCastableContext(),
-    ) {
-        debug("NEW RemotePlayerController with:", player);
-        this.player.controller = this;
-    }
-
-    public addEventListener(
-        type: RemotePlayerEventType,
-        handler: Listener<RemotePlayerChangedEvent>,
-    ) {
-        debug("addEventListener(", type, ")");
-        this.events.on(type, handler);
-
-        const firstListener = !this.totalListeners;
-        ++this.totalListeners;
-
-        if (firstListener) {
-            this.subscribeToEvents();
-        }
-    }
-
-    public getFormattedTime(timeInSec: number) {
-        // NOTE: per docs, intervals > 100 hours get truncated
-        const time = Math.min(MAX_FORMATTABLE_TIME, timeInSec);
-
-        const hours = Math.floor(time / 3600);
-        const minutes = Math.floor((time % 3600) / 60);
-        const seconds = time - (hours * 3600) - (minutes * 60);
-
-        const hoursZero = hours < 10 ? "0" : "";
-        const minutesZero = minutes < 10 ? "0" : "";
-        const secondsZero = seconds < 10 ? "0" : "";
-
-        return `${hoursZero}${hours}:${minutesZero}${minutes}:${secondsZero}${seconds}`;
-    }
-
-    public getSeekPosition(currentTime: number, duration: number) {
-        if (duration <= 0) return 0;
-        return currentTime / duration;
-    }
-
-    public getSeekTime(currentPosition: number, duration: number) {
-        return currentPosition * duration;
-    }
-
-    public readonly muteOrUnmute = this.createMediaCommand(media => ({
-        type: "SET_VOLUME",
-        volume: {
-            muted: media.volume?.muted === false,
-        },
-    }));
-
-    public readonly playOrPause = this.createMediaCommand(media => ({
-        type: media.playerState === PlayerState.PLAYING
-            ? "PAUSE"
-            : "PLAY",
-    }));
-
-    public readonly seek = this.createMediaCommand(() => ({
-        type: "SEEK",
-        currentTime: this.player.currentTime,
-    }));
-
-    public readonly setVolumeLevel = this.createMediaCommand(() => ({
-        type: "SET_VOLUME",
-        volume: {
-            level: this.player.volumeLevel,
-        },
-    }));
-
-    public skipAd = this.createSimpleMediaCommand("SKIP_AD");
-    public stop = this.createSimpleMediaCommand("STOP");
-
-    public removeEventListener(
-        type: RemotePlayerEventType,
-        handler: Listener<RemotePlayerChangedEvent>,
-    ) {
-        this.events.off(type, handler);
-        --this.totalListeners;
-        const isLast = !this.totalListeners;
-
-        if (isLast) {
-            this.unsubscribeFromEvents();
-        }
-    }
-
-    private createSimpleMediaCommand(type: string) {
-        return this.createMediaCommand(() => ({ type }));
-    }
-
-    private createMediaCommand(
-        build: (media: Media) => IPartialMediaCommand,
-    ) {
-        return () => {
-            debug("media command send requested...");
-
-            const session = this.context.getCurrentSession();
-            if (!session) throw new Error("No session");
-
-            const media = session.getMediaSession();
-            if (!media) {
-                debug("NO media session; abandon send request");
-                return;
-            }
-
-            const command = build(media);
-
-            debug("sending media command:", command);
-            return session.io.rpc.sendMediaCommand({
-                ...command,
-                mediaSessionId: media.mediaSessionId,
-            });
-        };
-    }
-
-    private async subscribeToEvents() {
-        debug("subscribe to media events");
-        const session = await this.awaitSession();
-        session.addEventListener(SessionEventType.MEDIA_SESSION, this.onMediaSession);
-    }
-
-    private async unsubscribeFromEvents() {
-        debug("unsubscribe from media events");
-        const session = this.context.getCurrentSession();
-        if (session) {
-            session.removeEventListener(
-                SessionEventType.MEDIA_SESSION,
-                this.onMediaSession,
-            );
-        }
-    }
-
-    private onMediaSession = (session: MediaSessionEventData) => {
-        debug("TODO media=", session.mediaSession);
-        // TODO update the Player and dispatch events
-    };
-
-    private async awaitSession() {
-        const { context } = this;
-        const session = context.getCurrentSession();
-        if (session) return session;
-
-        return new Promise<CastSession>(resolve => {
-            function listener(event: SessionStateEventData) {
-                resolve(event.session);
-                context.removeEventListener(
-                    CastContextEventType.SESSION_STATE_CHANGED,
-                    listener,
-                );
-            }
-
-            context.addEventListener(CastContextEventType.SESSION_STATE_CHANGED, listener);
-        });
-    }
+    public whenSkippable?: number;
 }

--- a/castable Extension/ts/cast.ts
+++ b/castable Extension/ts/cast.ts
@@ -10,10 +10,8 @@ import {
     SessionEventType,
     SessionState,
 } from "./cast.framework/enums";
-import {
-    RemotePlayer,
-    RemotePlayerController,
-} from "./cast.framework/remote-player";
+import { RemotePlayer } from "./cast.framework/remote-player";
+import { RemotePlayerController } from "./cast.framework/remote-player-controller";
 
 class StaticClassContext {
     constructor(

--- a/castable Extension/ts/cast.ts
+++ b/castable Extension/ts/cast.ts
@@ -6,6 +6,7 @@ import {
     ActiveInputState,
     CastContextEventType,
     CastState,
+    RemotePlayerEventType,
     SessionEventType,
     SessionState,
 } from "./cast.framework/enums";
@@ -25,6 +26,8 @@ class StaticClassContext {
 }
 
 class FrameworkStub {
+    public readonly VERSION = "1.0.14";
+
     public readonly ActiveInputState = ActiveInputState;
     public readonly CastState = CastState;
     public readonly SessionState = SessionState;
@@ -32,6 +35,7 @@ class FrameworkStub {
     public readonly CastContext: StaticClassContext;
     public readonly RemotePlayer = RemotePlayer;
     public readonly RemotePlayerController = RemotePlayerController;
+    public readonly RemotePlayerEventType = RemotePlayerEventType;
     public readonly SessionEventType = SessionEventType;
 
     constructor(

--- a/castable Extension/ts/chrome.cast/enums.ts
+++ b/castable Extension/ts/chrome.cast/enums.ts
@@ -30,6 +30,13 @@ export enum ErrorCode {
     LOAD_MEDIA_FAILED = "load_media_failed",
 }
 
+export enum MediaCommand {
+    PAUSE = "PAUSE",
+    SEEK = "SEEK",
+    STREAM_VOLUME = "STREAM_VOLUME",
+    STREAM_MUTE = "STREAM_MUTE",
+}
+
 export enum PlayerState {
     IDLE = "IDLE",
     PLAYING = "PLAYING",

--- a/castable Extension/ts/chrome.cast/media/media.ts
+++ b/castable Extension/ts/chrome.cast/media/media.ts
@@ -3,8 +3,10 @@ import { EventEmitter } from "events";
 
 import { SessionEventType } from "../../cast.framework/enums";
 import { IClientIO } from "../../io/model";
+import { PlayerState } from "../enums";
 import { Listener } from "../generic-types";
 import { callbackAsyncFunction } from "../util";
+import { Volume } from "../volume";
 
 import { SeekRequest } from "./seek-request";
 import { VolumeRequest } from "./volume-request";
@@ -35,6 +37,8 @@ const UPDATE_EVENT = "update";
 export class Media {
     public media: MediaInfo | undefined;
     public currentTime: number | undefined;
+    public playerState = PlayerState.IDLE;
+    public volume?: Volume;
 
     private readonly events = new EventEmitter();
     private readonly onUpdate = ({ mediaSession }: { mediaSession: Media }) => {

--- a/castable Extension/ts/chrome.cast/media/media.ts
+++ b/castable Extension/ts/chrome.cast/media/media.ts
@@ -12,6 +12,8 @@ import { SeekRequest } from "./seek-request";
 import { VolumeRequest } from "./volume-request";
 
 export class MediaInfo {
+    public metadata?: any;
+
     constructor(
         public readonly contentId: string,
         public readonly contentType: string,

--- a/castable Extension/ts/chrome.cast/media/media.ts
+++ b/castable Extension/ts/chrome.cast/media/media.ts
@@ -41,8 +41,11 @@ export class Media {
     public media: MediaInfo | undefined;
     public currentTime: number | undefined;
     public playerState = PlayerState.IDLE;
-    public supportedMediaCommands?: MediaCommand[];
     public volume?: Volume;
+
+    // FIXME: the correct type here is an array of MediaCommand; we need to
+    // transform this from what we get via the socket (an int mask)
+    public supportedMediaCommands?: number;
 
     private readonly events = new EventEmitter();
     private readonly onUpdate = ({ mediaSession }: { mediaSession: Media }) => {

--- a/castable Extension/ts/chrome.cast/media/media.ts
+++ b/castable Extension/ts/chrome.cast/media/media.ts
@@ -38,7 +38,7 @@ const debug = _debug("castable:chrome.cast.media.Media");
 const UPDATE_EVENT = "update";
 
 export class Media {
-    public media?: MediaInfo;
+    public media?: MediaInfo | null;
     public currentTime?: number;
     public playerState = PlayerState.IDLE;
     public volume?: Volume;

--- a/castable Extension/ts/chrome.cast/media/media.ts
+++ b/castable Extension/ts/chrome.cast/media/media.ts
@@ -3,7 +3,7 @@ import { EventEmitter } from "events";
 
 import { SessionEventType } from "../../cast.framework/enums";
 import { IClientIO } from "../../io/model";
-import { PlayerState } from "../enums";
+import { MediaCommand, PlayerState } from "../enums";
 import { Listener } from "../generic-types";
 import { callbackAsyncFunction } from "../util";
 import { Volume } from "../volume";
@@ -12,6 +12,7 @@ import { SeekRequest } from "./seek-request";
 import { VolumeRequest } from "./volume-request";
 
 export class MediaInfo {
+    public duration?: number;
     public metadata?: any;
 
     constructor(
@@ -40,6 +41,7 @@ export class Media {
     public media: MediaInfo | undefined;
     public currentTime: number | undefined;
     public playerState = PlayerState.IDLE;
+    public supportedMediaCommands?: MediaCommand[];
     public volume?: Volume;
 
     private readonly events = new EventEmitter();

--- a/castable Extension/ts/chrome.cast/media/media.ts
+++ b/castable Extension/ts/chrome.cast/media/media.ts
@@ -3,7 +3,7 @@ import { EventEmitter } from "events";
 
 import { SessionEventType } from "../../cast.framework/enums";
 import { IClientIO } from "../../io/model";
-import { MediaCommand, PlayerState } from "../enums";
+import { PlayerState } from "../enums";
 import { Listener } from "../generic-types";
 import { callbackAsyncFunction } from "../util";
 import { Volume } from "../volume";
@@ -38,8 +38,8 @@ const debug = _debug("castable:chrome.cast.media.Media");
 const UPDATE_EVENT = "update";
 
 export class Media {
-    public media: MediaInfo | undefined;
-    public currentTime: number | undefined;
+    public media?: MediaInfo;
+    public currentTime?: number;
     public playerState = PlayerState.IDLE;
     public volume?: Volume;
 

--- a/castable Extension/ts/chrome.ts
+++ b/castable Extension/ts/chrome.ts
@@ -92,12 +92,10 @@ class ChromeCastStub {
         context.addEventListener(CastContextEventType.SESSION_STATE_CHANGED, wrapper);
     }
 
-    // eslint-disable-next-line class-methods-use-this
     public logMessage(message: any) {
         debug("logMessage:", message);
     }
 
-    // eslint-disable-next-line class-methods-use-this
     public precache(data: any) {
         debug("precache:", data);
     }
@@ -133,7 +131,6 @@ class ChromeCastStub {
         },
     );
 
-    // eslint-disable-next-line class-methods-use-this
     public requestSessionById(id: string) {
         debug("TODO requestSessionById", id);
     }
@@ -147,7 +144,6 @@ class ChromeCastStub {
         },
     );
 
-    // eslint-disable-next-line class-methods-use-this
     public setPageContext(win: any) {
         debug("TODO setPageContext", win);
     }
@@ -159,7 +155,6 @@ class ChromeCastStub {
         },
     );
 
-    // eslint-disable-next-line class-methods-use-this
     public unescape(s: string) {
         debug("unescape", s);
         return unescape(s); // ?!

--- a/castable Extension/ts/compat/youtube.ts
+++ b/castable Extension/ts/compat/youtube.ts
@@ -9,8 +9,6 @@ const extraAgentConfig = " + Chrome/80+Android";
 const debug = _debug("castable:compat:youtube");
 
 export class YoutubeCompat implements CompatApplier {
-    // allow lack of "this"; it's an interface method
-    // eslint-disable-next-line class-methods-use-this
     public apply({ actualUserAgent, host }: CompatContext) {
         if (!host.endsWith("youtube.com")) return; // nop
 

--- a/castable Extension/ts/io/model.ts
+++ b/castable Extension/ts/io/model.ts
@@ -5,10 +5,13 @@ export interface ClientEvent {
     args?: any,
 }
 
-export interface IMediaCommand {
+export interface IPartialMediaCommand {
     type: string;
-    mediaSessionId: string;
     [key: string]: any;
+}
+
+export interface IMediaCommand extends IPartialMediaCommand {
+    mediaSessionId: string;
 }
 
 export interface IRpc {


### PR DESCRIPTION
See #8 

- Add RemotePlayerEventType
- Scaffold out the RemotePlayerController methods
- Build out media commands implementation for RemotePlayerController
- Scaffold out Media subscription for powering RemotePlayerController
- Add initial mechanism for transforming Media events to RemotePlayer
- Fill out a handful of RemotePlayer transforms
