### PR TITLE
Add Hulu support!

### DIFF
--- a/castable Extension/ts/chrome.ts
+++ b/castable Extension/ts/chrome.ts
@@ -68,7 +68,11 @@ class ChromeCastStub {
             this.config = apiConfig;
 
             // FIXME: get this state from the extension
-            apiConfig.receiverListener(ReceiverAvailability.AVAILABLE);
+            // NOTE: for best compat, we wait until after this function
+            // returns to notify the receiver
+            setTimeout(() => {
+                apiConfig.receiverListener(ReceiverAvailability.AVAILABLE);
+            });
         },
     );
 

--- a/castable Extension/ts/chrome.ts
+++ b/castable Extension/ts/chrome.ts
@@ -52,6 +52,7 @@ class ChromeCastStub {
     public readonly timeout = proxy(new TimeoutStub(), "chrome.cast.timeout");
 
     public readonly isAvailable = true;
+    public readonly usingPresentationApi = false;
 
     private config: ApiConfig | undefined;
 

--- a/castable Extension/ts/compat.ts
+++ b/castable Extension/ts/compat.ts
@@ -1,8 +1,13 @@
+import { AgentAndPresentationCompat } from "./compat/agent";
+import { onHost } from "./compat/matchers";
+import { CompatApplier, CompatContext, CompatMatcher } from "./compat/model";
 import { YoutubeCompat } from "./compat/youtube";
-import { CompatContext } from "./compat/model";
 
-const compats = [
-    new YoutubeCompat(),
+const compats: [CompatMatcher, CompatApplier][] = [
+    [onHost("hulu.com"), new AgentAndPresentationCompat()],
+
+    [onHost("youtube.com"), new AgentAndPresentationCompat()],
+    [onHost("youtube.com"), new YoutubeCompat()],
 ];
 
 export function applyCompat() {
@@ -11,7 +16,10 @@ export function applyCompat() {
         host: window.location.host,
         window,
     };
-    for (const compat of compats) {
-        compat.apply(context);
+
+    for (const [matcher, compat] of compats) {
+        if (matcher(context)) {
+            compat.apply(context);
+        }
     }
 }

--- a/castable Extension/ts/compat/agent.ts
+++ b/castable Extension/ts/compat/agent.ts
@@ -1,0 +1,36 @@
+import _debug from "debug";
+import { proxy } from "../proxy";
+
+import { CompatApplier, CompatContext } from "./model";
+
+// NOTE: this extra agent stuff convinces the cast_sender.js
+// to initialize its chromecast support
+const extraAgentConfig = " + Chrome/80+Android";
+
+const debug = _debug("castable:compat:agent");
+
+/**
+ * AgentAndPresentationCompat stubs the `navigator.userAgent` and
+ * `.presentation` vars to make the page believe it is on Chrome
+ */
+export class AgentAndPresentationCompat implements CompatApplier {
+    public apply({ actualUserAgent }: CompatContext) {
+        const patchedUserAgent = actualUserAgent + extraAgentConfig;
+
+        // patch the userAgent in case it hasn't already been read
+        Object.defineProperties(window.navigator, {
+            userAgent: {
+                value: patchedUserAgent,
+            },
+
+            presentation: {
+                get() {
+                    debug("READ window.navigator.presentation");
+                    return proxy({}, "window.navigator.presentation");
+                },
+            },
+        });
+
+        debug("Applied user agent patch: ", patchedUserAgent);
+    }
+}

--- a/castable Extension/ts/compat/matchers.ts
+++ b/castable Extension/ts/compat/matchers.ts
@@ -1,0 +1,5 @@
+import { CompatContext } from "./model";
+
+export function onHost(desiredHost: string) {
+    return ({ host }: CompatContext) => host.endsWith(desiredHost);
+}

--- a/castable Extension/ts/compat/model.ts
+++ b/castable Extension/ts/compat/model.ts
@@ -4,6 +4,10 @@ export interface CompatContext {
     window: Window;
 }
 
+export interface CompatMatcher {
+    (context: CompatContext): boolean;
+}
+
 export interface CompatApplier {
     apply(context: CompatContext): void;
 }

--- a/castable Extension/ts/compat/youtube.ts
+++ b/castable Extension/ts/compat/youtube.ts
@@ -2,17 +2,11 @@ import _debug from "debug";
 
 import { CompatApplier, CompatContext } from "./model";
 
-// NOTE: this extra agent stuff convinces Youtube's JS
-// to initialize its chromecast support
-const extraAgentConfig = " + Chrome/80+Android";
-
 const debug = _debug("castable:compat:youtube");
 
 export class YoutubeCompat implements CompatApplier {
-    public apply({ actualUserAgent, host }: CompatContext) {
-        if (!host.endsWith("youtube.com")) return; // nop
-
-        const patchedUserAgent = actualUserAgent + extraAgentConfig;
+    public apply({ actualUserAgent }: CompatContext) {
+        const patchedUserAgent = window.navigator.userAgent;
 
         // it's the name of the var; not much we can do about the dangle:
         // eslint-disable-next-line no-underscore-dangle
@@ -23,16 +17,9 @@ export class YoutubeCompat implements CompatApplier {
                 actualUserAgent,
                 patchedUserAgent,
             );
+
+            debug("Applied YT patch: ", patchedUserAgent);
         }
-
-        // patch the userAgent in case it hasn't already been read
-        Object.defineProperties(window.navigator, {
-            userAgent: {
-                value: patchedUserAgent,
-            },
-        });
-
-        debug("Applied YT user agent patch: ", patchedUserAgent);
     }
 
     private static applyAgentBackport(

--- a/castable Extension/ts/proxy.ts
+++ b/castable Extension/ts/proxy.ts
@@ -19,6 +19,18 @@ export function proxy<T extends object>(
 
             return got;
         },
+
+        set(target, prop, value, receiver) {
+            const got = Reflect.get(target, prop, receiver);
+            const had = got !== undefined;
+
+            if (!had) {
+                debug("WRITE ", name ?? actual, ".", prop, `(found ${had})`, " <- ", value);
+                Reflect.set(target, prop, value, receiver);
+            }
+
+            return true;
+        },
     });
     return proxyObject as unknown as T;
 }

--- a/castable Extension/ts/stub.ts
+++ b/castable Extension/ts/stub.ts
@@ -8,6 +8,16 @@ import { proxy } from "./proxy";
 
 const debug = _debug("castable:stub");
 
+function isInCastFramework() {
+    const script = document.currentScript;
+    if (!(script instanceof HTMLScriptElement)) {
+        // definitely not
+        return false;
+    }
+
+    return script.src.endsWith("/cast_framework.js");
+}
+
 /**
  * Initializes chromecast stubbing
  */
@@ -32,6 +42,8 @@ export function init() {
     const chromeProxy = proxy(controller.chrome, "chrome");
     const castProxy = proxy(cast, "cast");
 
+    let providedCast: any | undefined;
+
     Object.defineProperties(window, {
         chrome: {
             get() {
@@ -39,25 +51,50 @@ export function init() {
                     return chromeProxy;
                 }
             },
+
+            set(value) {
+                debug("SET window.chrome <-", value);
+            },
         },
 
         cast: {
             get() {
+                if (providedCast) {
+                    return providedCast;
+                }
+
+                if (isInCastFramework()) {
+                    // when accessed from cast_framework.js, we should
+                    // ONLY reflect whatever value they're providing
+                    // (via providedCast)
+                    return;
+                }
+
                 if (controller.receivedApiAvailableHandler) {
                     return castProxy;
                 }
+            },
+
+            set(value) {
+                debug("SET window.cast <-", value);
+                providedCast = proxy(value, "cast");
+                return true;
             },
         },
 
         __onGCastApiAvailable: {
             get() {
-                debug("READ onGCastApiAvailable <- ", typeof controller.onGCastApiAvailable);
-                return controller.onGCastApiAvailable;
+                debug("READ onGCastApiAvailable <- ", typeof controller.receivedApiAvailableHandler);
+                return controller.receivedApiAvailableHandler;
             },
 
             set(value) {
-                debug("set onGCastApiAvailable <- ", value);
-                controller.setGCastApiAvailableHandler(value);
+                debug("SET onGCastApiAvailable <- ", value);
+                // NOTE: for now, at least, we don't use this method
+                // to allow applications to propagate API availability
+                // as normal
+                // controller.setGCastApiAvailableHandler(value);
+                controller.receivedApiAvailableHandler = value;
             },
         },
     });


### PR DESCRIPTION
Future work should probably investigate whether we can manually load
cast_framework.js in response to `__onGCastApiAvailable(false)` (for
example) in order to more easily rely on Google's implementation
thereof, and to reduce our maintenance burden. If doable, we could
potentially completely strip out our cast.framework implementation and
rally around `chrome.cast` (probably keeping most of the implementations
under the hood, of course).

- Refactor compat to be more reusable
- Allow scripts to add new properties to proxy objects
- Let clients know that chrome.cast is NOT using the presentation API
- Improve Hulu compat

Fixes #12 